### PR TITLE
test: flush the handlers after use

### DIFF
--- a/test/integration/asymmetric-encrypt-decrypt.int.c
+++ b/test/integration/asymmetric-encrypt-decrypt.int.c
@@ -114,12 +114,16 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     session_data.hmac.t.size = 0;
 
     rc = TSS2_RETRY_EXP (Tss2_Sys_Create(sapi_context, sym_handle, &sessions_data, &in_sensitive, &in_public, &outside_info, &creation_pcr, &out_private, &out_public, &creation_data, &creation_hash, &creation_ticket, &sessions_data_out));
-    if (rc != TPM_RC_SUCCESS)
+    if (rc != TPM_RC_SUCCESS) {
+        Tss2_Sys_FlushContext( sapi_context, sym_handle );
         print_fail("Create FAILED! Response Code : 0x%x", rc);
+    }
 
     rc = Tss2_Sys_Load(sapi_context, sym_handle, &sessions_data, &out_private, &out_public, &loaded_sym_handle, &name, &sessions_data_out);
-    if (rc != TPM_RC_SUCCESS)
+    if (rc != TPM_RC_SUCCESS) {
+        Tss2_Sys_FlushContext( sapi_context, sym_handle );
         print_fail("Load FAILED! Response Code : 0x%x", rc);
+    }
     print_log( "Loaded key handle:  %8.8x\n", loaded_sym_handle );
 
     input_message.t.size = strlen(message);
@@ -127,12 +131,17 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     in_scheme.scheme = TPM_ALG_RSAES;
     outside_info.t.size = 0;
     rc = Tss2_Sys_RSA_Encrypt(sapi_context, loaded_sym_handle, 0, &input_message, &in_scheme, &outside_info, &output_data, 0);
-    if(rc != TPM_RC_SUCCESS)
+    if (rc != TPM_RC_SUCCESS) {
+        Tss2_Sys_FlushContext( sapi_context, loaded_sym_handle );
+        Tss2_Sys_FlushContext( sapi_context, sym_handle );
         print_fail("RSA_Encrypt FAILED! Response Code : 0x%x", rc);
+    }
     print_log("Encrypt successed.");
 
     rc = Tss2_Sys_RSA_Decrypt(sapi_context, loaded_sym_handle, &sessions_data, &output_data, &in_scheme, &outside_info, &output_message, &sessions_data_out);
-    if(rc != TPM_RC_SUCCESS)
+    Tss2_Sys_FlushContext( sapi_context, loaded_sym_handle );
+    Tss2_Sys_FlushContext( sapi_context, sym_handle );
+    if (rc != TPM_RC_SUCCESS)
         print_fail("RSA_Decrypt FAILED! Response Code : 0x%x", rc);
     print_log("Decrypt successed.");
 

--- a/test/integration/create-keyedhash-sha1-hmac.int.c
+++ b/test/integration/create-keyedhash-sha1-hmac.int.c
@@ -63,6 +63,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
                                           &creationHash,
                                           &creationTicket,
                                           &sessions_rsp));
+    Tss2_Sys_FlushContext( sapi_context, parent_handle );
     if (rc == TPM_RC_SUCCESS) {
         print_log ("success");
     } else {

--- a/test/integration/create-primary-rsa-2048-aes-128-cfb.int.c
+++ b/test/integration/create-primary-rsa-2048-aes-128-cfb.int.c
@@ -31,6 +31,11 @@ int
 test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 {
     TPM_HANDLE handle = 0;
+    TSS2_RC rc;
 
-    return create_primary_rsa_2048_aes_128_cfb (sapi_context, &handle);
+    rc = create_primary_rsa_2048_aes_128_cfb (sapi_context, &handle);
+    if (rc == TPM_RC_SUCCESS)
+        Tss2_Sys_FlushContext( sapi_context, handle );
+
+    return rc;
 }

--- a/test/integration/evict-ctrl.int.c
+++ b/test/integration/evict-ctrl.int.c
@@ -41,5 +41,8 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
                    primary_handle, rc);
     }
 
+    Tss2_Sys_FlushContext( sapi_context, 0x81000000 );
+    Tss2_Sys_FlushContext( sapi_context, primary_handle );
+
     return rc;
 }


### PR DESCRIPTION
The unused handlers may exhaust the RAM of a real TPM hardware with
such a failure:

PASS: test/integration/asymmetric-encrypt-decrypt.int
PASS: test/integration/create-primary-rsa-2048-aes-128-cfb.int
PASS: test/integration/create-keyedhash-sha1-hmac.int
FAIL: test/integration/evict-ctrl.int

test/integration/sapi-util.c:82:create_primary_rsa_2048_aes_128_cfb():
CreatePrimary RSA 2048, AES 128 CFB
test/integration/sapi-util.c:100:create_primary_rsa_2048_aes_128_cfb():
CreatePrimary FAILED! Response Code : 0x902

It is fine to clean up the unused handlers before exit.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>