### PR TITLE
test: Use built-in mock with cast functions instead of manual casting.

### DIFF
--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -128,12 +128,12 @@ tcti_device_log_called_test (void **state)
 ssize_t
 __wrap_read (int fd, void *buffer, size_t count)
 {
-    return (ssize_t)mock ();
+    return mock_type (ssize_t);
 }
 ssize_t
 __wrap_write (int fd, const void *buffer, size_t buffer_size)
 {
-    return (ssize_t)mock ();
+    return mock_type (ssize_t);
 }
 
 typedef struct {

--- a/test/unit/tcti-socket.c
+++ b/test/unit/tcti-socket.c
@@ -84,7 +84,7 @@ __wrap_connect (int                    sockfd,
                 const struct sockaddr *addr,
                 socklen_t              addrlen)
 {
-    return (int)mock ();
+    return mock_type (int);
 }
 /*
  * Wrap the 'recv' system call. The mock queue for this function must have an
@@ -97,8 +97,8 @@ __wrap_recv (int sockfd,
              size_t len,
              int flags)
 {
-    ssize_t  ret = (ssize_t)mock ();
-    uint8_t *buf_in = (uint8_t*)mock ();
+    ssize_t  ret = mock_type (ssize_t);
+    uint8_t *buf_in = mock_ptr_type (uint8_t*);
 
     memcpy (buf, buf_in, ret);
     return ret;
@@ -115,7 +115,7 @@ __wrap_select (int             nfds,
                fd_set         *exceptfds,
                struct timeval *timeout)
 {
-    return (int)mock ();
+    return mock_type (int);
 }
 /*
  * Wrap the 'send' system call. The mock queue for this function must have an
@@ -128,7 +128,7 @@ __wrap_send (int         sockfd,
              int         flags)
 
 {
-    return (TSS2_RC)mock ();
+    return mock_type (TSS2_RC);
 }
 /*
  * This is a utility function used by other tests to setup a TCTI context. It


### PR DESCRIPTION
This is a cherry-pick from master for compatibility with GCC5.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>