### PR TITLE
README.md: Account for renaming of github org from 01org to intel in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/01org/tpm2-tss.svg?branch=master)](https://travis-ci.org/01org/tpm2-tss)
+[![Build Status](https://travis-ci.org/intel/tpm2-tss.svg?branch=master)](https://travis-ci.org/intel/tpm2-tss)
 [![Coverity Scan](https://img.shields.io/coverity/scan/3997.svg)](https://scan.coverity.com/projects/tpm2-tss)
 
 # Overview


### PR DESCRIPTION
…travis-ci URL.

A bit dissappointing that travis-ci picks up the rename automatically but
coverity is completely unable to rename projects at all. They can only
be deleted and replaced by a new project. Presumably all scan history
will be lost if we do this :(

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>