### PR TITLE
build: Check for cmocka version >= 1.0 @ configure time.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_ARG_ENABLE([unit],
             [enable_unit=no])
 AS_IF([test "x$enable_unit" != xno],
       [PKG_CHECK_MODULES([CMOCKA],
-                         [cmocka],
+                         [cmocka >= 1.0],
                          [AC_DEFINE([HAVE_CMOCKA],
                                     [1])])])
 AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])


### PR DESCRIPTION
This is to keep developers with an old version of cmocka from having to
deal with compile time errors when we can catch this at configure time.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>