### PR TITLE
implementation.h: drop the casts and parens on Algs

### DIFF
--- a/include/sapi/implementation.h
+++ b/include/sapi/implementation.h
@@ -322,149 +322,149 @@
 // From TCG Algorithm Registry: Table 2 - Definition of TPM_ALG_ID Constants
 
 typedef  UINT16             TPM_ALG_ID;
-#define  TPM_ALG_ERROR               (TPM_ALG_ID)(0x0000)
+#define  TPM_ALG_ERROR               0x0000
 #define  ALG_ERROR_VALUE             0x0000
 #if defined ALG_RSA && ALG_RSA == YES
-#define  TPM_ALG_RSA                 (TPM_ALG_ID)(0x0001)
+#define  TPM_ALG_RSA                 0x0001
 #endif
 #define  ALG_RSA_VALUE               0x0001
 #if defined ALG_SHA && ALG_SHA == YES
-#define  TPM_ALG_SHA                 (TPM_ALG_ID)(0x0004)
+#define  TPM_ALG_SHA                 0x0004
 #endif
 #define  ALG_SHA_VALUE               0x0004
 #if defined ALG_SHA1 && ALG_SHA1 == YES
-#define  TPM_ALG_SHA1                (TPM_ALG_ID)(0x0004)
+#define  TPM_ALG_SHA1                0x0004
 #endif
 #define  ALG_SHA1_VALUE              0x0004
 #if defined ALG_HMAC && ALG_HMAC == YES
-#define  TPM_ALG_HMAC                (TPM_ALG_ID)(0x0005)
+#define  TPM_ALG_HMAC                0x0005
 #endif
 #define  ALG_HMAC_VALUE              0x0005
 #if defined ALG_AES && ALG_AES == YES
-#define  TPM_ALG_AES                 (TPM_ALG_ID)(0x0006)
+#define  TPM_ALG_AES                 0x0006
 #endif
 #define  ALG_AES_VALUE               0x0006
 #if defined ALG_MGF1 && ALG_MGF1 == YES
-#define  TPM_ALG_MGF1                (TPM_ALG_ID)(0x0007)
+#define  TPM_ALG_MGF1                0x0007
 #endif
 #define  ALG_MGF1_VALUE              0x0007
 #if defined ALG_KEYEDHASH && ALG_KEYEDHASH == YES
-#define  TPM_ALG_KEYEDHASH           (TPM_ALG_ID)(0x0008)
+#define  TPM_ALG_KEYEDHASH           0x0008
 #endif
 #define  ALG_KEYEDHASH_VALUE         0x0008
 #if defined ALG_XOR && ALG_XOR == YES
-#define  TPM_ALG_XOR                 (TPM_ALG_ID)(0x000A)
+#define  TPM_ALG_XOR                 0x000A
 #endif
 #define  ALG_XOR_VALUE               0x000A
 #if defined ALG_SHA256 && ALG_SHA256 == YES
-#define  TPM_ALG_SHA256              (TPM_ALG_ID)(0x000B)
+#define  TPM_ALG_SHA256              0x000B
 #endif
 #define  ALG_SHA256_VALUE            0x000B
 #if defined ALG_SHA384 && ALG_SHA384 == YES
-#define  TPM_ALG_SHA384              (TPM_ALG_ID)(0x000C)
+#define  TPM_ALG_SHA384              0x000C
 #endif
 #define  ALG_SHA384_VALUE            0x000C
 #if defined ALG_SHA512 && ALG_SHA512 == YES
-#define  TPM_ALG_SHA512              (TPM_ALG_ID)(0x000D)
+#define  TPM_ALG_SHA512              0x000D
 #endif
 #define  ALG_SHA512_VALUE            0x000D
-#define  TPM_ALG_NULL                (TPM_ALG_ID)(0x0010)
+#define  TPM_ALG_NULL                0x0010
 #define  ALG_NULL_VALUE              0x0010
 #if defined ALG_SM3_256 && ALG_SM3_256 == YES
-#define  TPM_ALG_SM3_256             (TPM_ALG_ID)(0x0012)
+#define  TPM_ALG_SM3_256             0x0012
 #endif
 #define  ALG_SM3_256_VALUE           0x0012
 #if defined ALG_SM4 && ALG_SM4 == YES
-#define  TPM_ALG_SM4                 (TPM_ALG_ID)(0x0013)
+#define  TPM_ALG_SM4                 0x0013
 #endif
 #define  ALG_SM4_VALUE               0x0013
 #if defined ALG_RSASSA && ALG_RSASSA == YES
-#define  TPM_ALG_RSASSA              (TPM_ALG_ID)(0x0014)
+#define  TPM_ALG_RSASSA              0x0014
 #endif
 #define  ALG_RSASSA_VALUE            0x0014
 #if defined ALG_RSAES && ALG_RSAES == YES
-#define  TPM_ALG_RSAES               (TPM_ALG_ID)(0x0015)
+#define  TPM_ALG_RSAES               0x0015
 #endif
 #define  ALG_RSAES_VALUE             0x0015
 #if defined ALG_RSAPSS && ALG_RSAPSS == YES
-#define  TPM_ALG_RSAPSS              (TPM_ALG_ID)(0x0016)
+#define  TPM_ALG_RSAPSS              0x0016
 #endif
 #define  ALG_RSAPSS_VALUE            0x0016
 #if defined ALG_OAEP && ALG_OAEP == YES
-#define  TPM_ALG_OAEP                (TPM_ALG_ID)(0x0017)
+#define  TPM_ALG_OAEP                0x0017
 #endif
 #define  ALG_OAEP_VALUE              0x0017
 #if defined ALG_ECDSA && ALG_ECDSA == YES
-#define  TPM_ALG_ECDSA               (TPM_ALG_ID)(0x0018)
+#define  TPM_ALG_ECDSA               0x0018
 #endif
 #define  ALG_ECDSA_VALUE             0x0018
 #if defined ALG_ECDH && ALG_ECDH == YES
-#define  TPM_ALG_ECDH                (TPM_ALG_ID)(0x0019)
+#define  TPM_ALG_ECDH                0x0019
 #endif
 #define  ALG_ECDH_VALUE              0x0019
 #if defined ALG_ECDAA && ALG_ECDAA == YES
-#define  TPM_ALG_ECDAA               (TPM_ALG_ID)(0x001A)
+#define  TPM_ALG_ECDAA               0x001A
 #endif
 #define  ALG_ECDAA_VALUE             0x001A
 #if defined ALG_SM2 && ALG_SM2 == YES
-#define  TPM_ALG_SM2                 (TPM_ALG_ID)(0x001B)
+#define  TPM_ALG_SM2                 0x001B
 #endif
 #define  ALG_SM2_VALUE               0x001B
 #if defined ALG_ECSCHNORR && ALG_ECSCHNORR == YES
-#define  TPM_ALG_ECSCHNORR           (TPM_ALG_ID)(0x001C)
+#define  TPM_ALG_ECSCHNORR           0x001C
 #endif
 #define  ALG_ECSCHNORR_VALUE         0x001C
 #if defined ALG_ECMQV && ALG_ECMQV == YES
-#define  TPM_ALG_ECMQV               (TPM_ALG_ID)(0x001D)
+#define  TPM_ALG_ECMQV               0x001D
 #endif
 #define  ALG_ECMQV_VALUE             0x001D
 #if defined ALG_KDF1_SP800_56A && ALG_KDF1_SP800_56A == YES
-#define  TPM_ALG_KDF1_SP800_56A      (TPM_ALG_ID)(0x0020)
+#define  TPM_ALG_KDF1_SP800_56A      0x0020
 #endif
 #define  ALG_KDF1_SP800_56A_VALUE    0x0020
 #if defined ALG_KDF2 && ALG_KDF2 == YES
-#define  TPM_ALG_KDF2                (TPM_ALG_ID)(0x0021)
+#define  TPM_ALG_KDF2                0x0021
 #endif
 #define  ALG_KDF2_VALUE              0x0021
 #if defined ALG_KDF1_SP800_108 && ALG_KDF1_SP800_108 == YES
-#define  TPM_ALG_KDF1_SP800_108      (TPM_ALG_ID)(0x0022)
+#define  TPM_ALG_KDF1_SP800_108      0x0022
 #endif
 #define  ALG_KDF1_SP800_108_VALUE    0x0022
 #if defined ALG_ECC && ALG_ECC == YES
-#define  TPM_ALG_ECC                 (TPM_ALG_ID)(0x0023)
+#define  TPM_ALG_ECC                 0x0023
 #endif
 #define  ALG_ECC_VALUE               0x0023
 #if defined ALG_SYMCIPHER && ALG_SYMCIPHER == YES
-#define  TPM_ALG_SYMCIPHER           (TPM_ALG_ID)(0x0025)
+#define  TPM_ALG_SYMCIPHER           0x0025
 #endif
 #define  ALG_SYMCIPHER_VALUE         0x0025
 #if defined ALG_CAMELLIA && ALG_CAMELLIA == YES
-#define  TPM_ALG_CAMELLIA            (TPM_ALG_ID)(0x0026)
+#define  TPM_ALG_CAMELLIA            0x0026
 #endif
 #define  ALG_CAMELLIA_VALUE          0x0026
 #if defined ALG_CTR && ALG_CTR == YES
-#define  TPM_ALG_CTR                 (TPM_ALG_ID)(0x0040)
+#define  TPM_ALG_CTR                 0x0040
 #endif
 #define  ALG_CTR_VALUE               0x0040
 #if defined ALG_OFB && ALG_OFB == YES
-#define  TPM_ALG_OFB                 (TPM_ALG_ID)(0x0041)
+#define  TPM_ALG_OFB                 0x0041
 #endif
 #define  ALG_OFB_VALUE               0x0041
 #if defined ALG_CBC && ALG_CBC == YES
-#define  TPM_ALG_CBC                 (TPM_ALG_ID)(0x0042)
+#define  TPM_ALG_CBC                 0x0042
 #endif
 #define  ALG_CBC_VALUE               0x0042
 #if defined ALG_CFB && ALG_CFB == YES
-#define  TPM_ALG_CFB                 (TPM_ALG_ID)(0x0043)
+#define  TPM_ALG_CFB                 0x0043
 #endif
 #define  ALG_CFB_VALUE               0x0043
 #if defined ALG_ECB && ALG_ECB == YES
-#define  TPM_ALG_ECB                 (TPM_ALG_ID)(0x0044)
+#define  TPM_ALG_ECB                 0x0044
 #endif
 #define  ALG_ECB_VALUE               0x0044
-#define  TPM_ALG_FIRST               (TPM_ALG_ID)(0x0001)
+#define  TPM_ALG_FIRST               0x0001
 #define  ALG_FIRST_VALUE             0x0001
-#define  TPM_ALG_LAST                (TPM_ALG_ID)(0x0044)
+#define  TPM_ALG_LAST                0x0044
 #define  ALG_LAST_VALUE              0x0044
 //     From TCG Algorithm Registry: Table 3 - Definition of TPM_ECC_CURVE Constants
 


### PR DESCRIPTION
The TPM_ALG_XXX defines cast the values as TPM_ALG_ID types.
There is really no need for this additional layer.

This cast, actually causes compilers to ignore the case when
things are oversized. For example, this code will cause no
overflow warning:

uint16_t x = (uint16_t)0x111111111111;

Where as this code will:
uint16_t x = 0x111111111111;

warning: large integer implicitly truncated to unsigned type [-Woverflow]

Signed-off-by: William Roberts <william.c.roberts@intel.com>