### PR TITLE
sapi: remove SYS_CONTEXT macro

### DIFF
--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -100,9 +100,25 @@ typedef struct {
     size_t nextData;
 } _TSS2_SYS_CONTEXT_BLOB;
 
-#define SYS_CONTEXT ((_TSS2_SYS_CONTEXT_BLOB *)sysContext)
-#define SYS_RESP_HEADER ((TPM20_Header_Out *)(SYS_CONTEXT->cmdBuffer))
-#define SYS_REQ_HEADER ((TPM20_Header_In *)(SYS_CONTEXT->cmdBuffer))
+struct TSS2_SYS_CONTEXT;
+
+static inline _TSS2_SYS_CONTEXT_BLOB *
+syscontext_cast(TSS2_SYS_CONTEXT *ctx)
+{
+    return (_TSS2_SYS_CONTEXT_BLOB*) ctx;
+}
+
+static inline TPM20_Header_Out *
+resp_header_from_cxt(_TSS2_SYS_CONTEXT_BLOB *ctx)
+{
+    return (TPM20_Header_Out *)ctx->cmdBuffer;
+}
+
+static inline TPM20_Header_In *
+req_header_from_cxt(_TSS2_SYS_CONTEXT_BLOB *ctx)
+{
+    return (TPM20_Header_In *)ctx->cmdBuffer;
+}
 
 typedef struct {
     TPM2_CC commandCode;
@@ -119,50 +135,40 @@ struct TSS2_SYS_CONTEXT;
 #ifdef __cplusplus
 extern "C" {
 #endif
-TSS2_RC CopyCommandHeader(TSS2_SYS_CONTEXT *sysContext, TPM2_CC commandCode);
-UINT16 GetDigestSize( TPM2_ALG_ID authHash );
-UINT32 GetCommandSize( TSS2_SYS_CONTEXT *sysContext );
 
-TSS2_RC ConcatSizedByteBuffer( TPM2B_MAX_BUFFER *result, TPM2B *addBuffer );
-
-void InitSysContextFields( TSS2_SYS_CONTEXT *sysContext );
-void InitSysContextPtrs ( TSS2_SYS_CONTEXT *sysContext, size_t contextSize );
-
-TSS2_RC CompleteChecks( TSS2_SYS_CONTEXT *sysContext );
-
-TSS2_RC CommonComplete( TSS2_SYS_CONTEXT *sysContext );
+TSS2_RC CopyCommandHeader(_TSS2_SYS_CONTEXT_BLOB *ctx, TPM2_CC commandCode);
+UINT16 GetDigestSize(TPM2_ALG_ID authHash);
+UINT32 GetCommandSize(_TSS2_SYS_CONTEXT_BLOB *ctx);
+TSS2_RC ConcatSizedByteBuffer(TPM2B_MAX_BUFFER *result, TPM2B *addBuffer);
+void InitSysContextFields(_TSS2_SYS_CONTEXT_BLOB *ctx);
+void InitSysContextPtrs(_TSS2_SYS_CONTEXT_BLOB *ctx, size_t contextSize);
+TSS2_RC CompleteChecks(_TSS2_SYS_CONTEXT_BLOB *ctx);
+TSS2_RC CommonComplete(_TSS2_SYS_CONTEXT_BLOB *ctx);
 
 TSS2_RC  CommonOneCallForNoResponseCmds(
-    TSS2_SYS_CONTEXT *sysContext,
+    _TSS2_SYS_CONTEXT_BLOB *ctx,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );
+    TSS2_SYS_RSP_AUTHS *rspAuthsArray);
 
 TSS2_RC CommonOneCall(
-    TSS2_SYS_CONTEXT *sysContext,
+    _TSS2_SYS_CONTEXT_BLOB *ctx,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );
+    TSS2_SYS_RSP_AUTHS *rspAuthsArray);
 
 TSS2_RC CommonPreparePrologue(
-    TSS2_SYS_CONTEXT *sysContext,
-    TPM2_CC commandCode
-    );
+    _TSS2_SYS_CONTEXT_BLOB *ctx,
+    TPM2_CC commandCode);
 
-TSS2_RC CommonPrepareEpilogue(
-    TSS2_SYS_CONTEXT *sysContext
-    );
-
-int GetNumCommandHandles( TPM2_CC commandCode );
-int GetNumResponseHandles( TPM2_CC commandCode );
+TSS2_RC CommonPrepareEpilogue(_TSS2_SYS_CONTEXT_BLOB *ctx);
+int GetNumCommandHandles(TPM2_CC commandCode);
+int GetNumResponseHandles(TPM2_CC commandCode);
 
 TSS2_SYS_CONTEXT *InitSysContext(
     UINT16 maxCommandSize,
     TSS2_TCTI_CONTEXT *tctiContext,
-    TSS2_ABI_VERSION *abiVersion
- );
+    TSS2_ABI_VERSION *abiVersion);
 
-void TeardownSysContext( TSS2_SYS_CONTEXT **sysContext );
+void TeardownSysContext(TSS2_SYS_CONTEXT **ctx);
 
 #ifdef __cplusplus
 }

--- a/sysapi/sysapi/ContextManagement.c
+++ b/sysapi/sysapi/ContextManagement.c
@@ -45,7 +45,9 @@ TSS2_RC Tss2_Sys_Initialize(
     TSS2_TCTI_CONTEXT *tctiContext,
     TSS2_ABI_VERSION *abiVersion)
 {
-    if (!sysContext || !tctiContext || !abiVersion)
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx || !tctiContext || !abiVersion)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
     if (contextSize < sizeof(_TSS2_SYS_CONTEXT_BLOB))
@@ -61,10 +63,10 @@ TSS2_RC Tss2_Sys_Initialize(
         abiVersion->tssVersion != TSS_SAPI_FIRST_LEVEL)
         return TSS2_SYS_RC_ABI_MISMATCH;
 
-    SYS_CONTEXT->tctiContext = tctiContext;
-    InitSysContextPtrs(sysContext, contextSize);
-    InitSysContextFields(sysContext);
-    SYS_CONTEXT->previousStage = CMD_STAGE_INITIALIZE;
+    ctx->tctiContext = tctiContext;
+    InitSysContextPtrs(ctx, contextSize);
+    InitSysContextFields(ctx);
+    ctx->previousStage = CMD_STAGE_INITIALIZE;
 
     return TSS2_RC_SUCCESS;
 }

--- a/sysapi/sysapi/GetCommandCode.c
+++ b/sysapi/sysapi/GetCommandCode.c
@@ -33,13 +33,15 @@ TSS2_RC Tss2_Sys_GetCommandCode(
     TSS2_SYS_CONTEXT *sysContext,
     UINT8 (*commandCode)[4])
 {
-    if (!sysContext || !commandCode)
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx || !commandCode)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (SYS_CONTEXT->previousStage == CMD_STAGE_INITIALIZE)
+    if (ctx->previousStage == CMD_STAGE_INITIALIZE)
         return TSS2_SYS_RC_BAD_SEQUENCE;
 
-    *(TPM2_CC *)commandCode = HOST_TO_BE_32(SYS_CONTEXT->commandCode);
+    *(TPM2_CC *)commandCode = HOST_TO_BE_32(ctx->commandCode);
 
     return TSS2_RC_SUCCESS;
 }

--- a/sysapi/sysapi/GetCpBuffer.c
+++ b/sysapi/sysapi/GetCpBuffer.c
@@ -33,14 +33,16 @@ TSS2_RC Tss2_Sys_GetCpBuffer(
     size_t *cpBufferUsedSize,
     const uint8_t **cpBuffer)
 {
-    if (!sysContext || !cpBufferUsedSize || !cpBuffer)
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx || !cpBufferUsedSize || !cpBuffer)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    if (SYS_CONTEXT->previousStage != CMD_STAGE_PREPARE)
+    if (ctx->previousStage != CMD_STAGE_PREPARE)
         return TSS2_SYS_RC_BAD_SEQUENCE;
 
-    *cpBuffer = SYS_CONTEXT->cpBuffer;
-    *cpBufferUsedSize = SYS_CONTEXT->cpBufferUsedSize;
+    *cpBuffer = ctx->cpBuffer;
+    *cpBufferUsedSize = ctx->cpBufferUsedSize;
 
     return TSS2_RC_SUCCESS;
 }

--- a/sysapi/sysapi/GetRpBuffer.c
+++ b/sysapi/sysapi/GetRpBuffer.c
@@ -33,17 +33,19 @@ TSS2_RC Tss2_Sys_GetRpBuffer(
     size_t *rpBufferUsedSize,
     const uint8_t **rpBuffer)
 {
-    if (!sysContext || !rpBufferUsedSize || !rpBuffer)
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx || !rpBufferUsedSize || !rpBuffer)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
     /* NOTE: should this depend on the status of previous
-     * API call? i.e. SYS_CONTEXT->rval != TSS2_RC_SUCCESS */
-    if (SYS_CONTEXT->previousStage != CMD_STAGE_RECEIVE_RESPONSE ||
-        SYS_CONTEXT->rval != TSS2_RC_SUCCESS)
+     * API call? i.e. ctx->rval != TSS2_RC_SUCCESS */
+    if (ctx->previousStage != CMD_STAGE_RECEIVE_RESPONSE ||
+        ctx->rval != TSS2_RC_SUCCESS)
         return TSS2_SYS_RC_BAD_SEQUENCE;
 
-    *rpBuffer = SYS_CONTEXT->rpBuffer;
-    *rpBufferUsedSize = SYS_CONTEXT->rpBufferUsedSize;
+    *rpBuffer = ctx->rpBuffer;
+    *rpBufferUsedSize = ctx->rpBufferUsedSize;
 
     return TSS2_RC_SUCCESS;
 }

--- a/sysapi/sysapi/GetTctiContext.c
+++ b/sysapi/sysapi/GetTctiContext.c
@@ -30,19 +30,14 @@
 
 TSS2_RC Tss2_Sys_GetTctiContext(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_TCTI_CONTEXT **tctiContext
-    )
+    TSS2_TCTI_CONTEXT **tctiContext)
 {
-    TSS2_RC rval = TSS2_RC_SUCCESS;
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
 
-    if( sysContext == 0 || tctiContext == 0 )
-    {
-        rval = TSS2_SYS_RC_BAD_REFERENCE;
-    }
-    else
-    {
-        *tctiContext = SYS_CONTEXT->tctiContext;
-    }
+    if (!ctx || !tctiContext)
+        return TSS2_SYS_RC_BAD_REFERENCE;
 
-    return rval;
+    *tctiContext = ctx->tctiContext;
+
+    return TSS2_RC_SUCCESS;
 }

--- a/sysapi/sysapi/Tss2_Sys_ActivateCredential.c
+++ b/sysapi/sysapi/Tss2_Sys_ActivateCredential.c
@@ -32,77 +32,79 @@ TSS2_RC Tss2_Sys_ActivateCredential_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT activateHandle,
     TPMI_DH_OBJECT keyHandle,
-    const TPM2B_ID_OBJECT	*credentialBlob,
-    const TPM2B_ENCRYPTED_SECRET	*secret)
+    const TPM2B_ID_OBJECT *credentialBlob,
+    const TPM2B_ENCRYPTED_SECRET *secret)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ActivateCredential);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ActivateCredential);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(activateHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(activateHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!credentialBlob) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
         rval = Tss2_MU_TPM2B_ID_OBJECT_Marshal(credentialBlob,
-                                               SYS_CONTEXT->cmdBuffer,
-                                               SYS_CONTEXT->maxCmdSize,
-                                               &SYS_CONTEXT->nextData);
+                                               ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(secret,
-                                                  SYS_CONTEXT->cmdBuffer,
-                                                  SYS_CONTEXT->maxCmdSize,
-                                                  &SYS_CONTEXT->nextData);
+                                                  ctx->cmdBuffer,
+                                                  ctx->maxCmdSize,
+                                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ActivateCredential_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_DIGEST *certInfo)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_DIGEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           certInfo);
 }
 
@@ -111,12 +113,13 @@ TSS2_RC Tss2_Sys_ActivateCredential(
     TPMI_DH_OBJECT activateHandle,
     TPMI_DH_OBJECT keyHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_ID_OBJECT	*credentialBlob,
-    const TPM2B_ENCRYPTED_SECRET	*secret,
+    const TPM2B_ID_OBJECT *credentialBlob,
+    const TPM2B_ENCRYPTED_SECRET *secret,
     TPM2B_DIGEST *certInfo,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
     TSS2_RC rval;
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
 
     rval = Tss2_Sys_ActivateCredential_Prepare(sysContext, activateHandle,
                                                keyHandle, credentialBlob,
@@ -124,7 +127,7 @@ TSS2_RC Tss2_Sys_ActivateCredential(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_Certify.c
+++ b/sysapi/sysapi/Tss2_Sys_Certify.c
@@ -32,56 +32,57 @@ TSS2_RC Tss2_Sys_Certify_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT objectHandle,
     TPMI_DH_OBJECT signHandle,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme)
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !inScheme)
+    if (!ctx || !inScheme)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Certify);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Certify);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(signHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!qualifyingData) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Certify_Complete(
@@ -89,25 +90,26 @@ TSS2_RC Tss2_Sys_Certify_Complete(
     TPM2B_ATTEST *certifyInfo,
     TPMT_SIGNATURE *signature)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           certifyInfo);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData,
                                             signature);
 }
 
@@ -116,13 +118,14 @@ TSS2_RC Tss2_Sys_Certify(
     TPMI_DH_OBJECT objectHandle,
     TPMI_DH_OBJECT signHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme,
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme,
     TPM2B_ATTEST *certifyInfo,
     TPMT_SIGNATURE *signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
     TSS2_RC rval;
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
 
     if (!inScheme)
         return TSS2_SYS_RC_BAD_REFERENCE;
@@ -132,7 +135,7 @@ TSS2_RC Tss2_Sys_Certify(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_CertifyCreation.c
+++ b/sysapi/sysapi/Tss2_Sys_CertifyCreation.c
@@ -32,71 +32,72 @@ TSS2_RC Tss2_Sys_CertifyCreation_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT signHandle,
     TPMI_DH_OBJECT objectHandle,
-    const TPM2B_DATA	*qualifyingData,
-    const TPM2B_DIGEST	*creationHash,
-    const TPMT_SIG_SCHEME	*inScheme,
-    const TPMT_TK_CREATION	*creationTicket)
+    const TPM2B_DATA *qualifyingData,
+    const TPM2B_DIGEST *creationHash,
+    const TPMT_SIG_SCHEME *inScheme,
+    const TPMT_TK_CREATION *creationTicket)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !inScheme || !creationTicket)
+    if (!ctx || !inScheme || !creationTicket)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_CertifyCreation);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_CertifyCreation);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(signHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!qualifyingData) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval =  Tss2_MU_TPM2B_DIGEST_Marshal(creationHash, SYS_CONTEXT->cmdBuffer,
-                                         SYS_CONTEXT->maxCmdSize,
-                                         &SYS_CONTEXT->nextData);
+    rval =  Tss2_MU_TPM2B_DIGEST_Marshal(creationHash, ctx->cmdBuffer,
+                                         ctx->maxCmdSize,
+                                         &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_TK_CREATION_Marshal(creationTicket, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_TK_CREATION_Marshal(creationTicket, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_CertifyCreation_Complete(
@@ -104,25 +105,26 @@ TSS2_RC Tss2_Sys_CertifyCreation_Complete(
     TPM2B_ATTEST *certifyInfo,
     TPMT_SIGNATURE *signature)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           certifyInfo);
     if (rval)
         return rval;
 
-    return rval = Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                   SYS_CONTEXT->maxCmdSize,
-                                                   &SYS_CONTEXT->nextData,
+    return rval = Tss2_MU_TPMT_SIGNATURE_Unmarshal(ctx->cmdBuffer,
+                                                   ctx->maxCmdSize,
+                                                   &ctx->nextData,
                                                    signature);
 }
 
@@ -131,14 +133,15 @@ TSS2_RC Tss2_Sys_CertifyCreation(
     TPMI_DH_OBJECT signHandle,
     TPMI_DH_OBJECT objectHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DATA	*qualifyingData,
-    const TPM2B_DIGEST	*creationHash,
-    const TPMT_SIG_SCHEME	*inScheme,
-    const TPMT_TK_CREATION	*creationTicket,
+    const TPM2B_DATA *qualifyingData,
+    const TPM2B_DIGEST *creationHash,
+    const TPMT_SIG_SCHEME *inScheme,
+    const TPMT_TK_CREATION *creationTicket,
     TPM2B_ATTEST *certifyInfo,
     TPMT_SIGNATURE *signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if( inScheme == NULL  || creationTicket == NULL  )
@@ -150,7 +153,7 @@ TSS2_RC Tss2_Sys_CertifyCreation(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_ChangeEPS.c
+++ b/sysapi/sysapi/Tss2_Sys_ChangeEPS.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_ChangeEPS_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ChangeEPS);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ChangeEPS);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ChangeEPS(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_ChangeEPS(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ChangeEPS_Prepare(sysContext, authHandle);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_ChangePPS.c
+++ b/sysapi/sysapi/Tss2_Sys_ChangePPS.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_ChangePPS_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ChangePPS);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ChangePPS);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ChangePPS(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_ChangePPS(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ChangePPS_Prepare(sysContext, authHandle);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_Clear.c
+++ b/sysapi/sysapi/Tss2_Sys_Clear.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_Clear_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_CLEAR authHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Clear);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Clear);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Clear(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_Clear(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_Clear_Prepare(sysContext, authHandle);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_ClearControl.c
+++ b/sysapi/sysapi/Tss2_Sys_ClearControl.c
@@ -33,32 +33,33 @@ TSS2_RC Tss2_Sys_ClearControl_Prepare(
     TPMI_RH_CLEAR auth,
     TPMI_YES_NO disable)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ClearControl);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ClearControl);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(auth, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(disable, SYS_CONTEXT->cmdBuffer,
-                                 SYS_CONTEXT->maxCmdSize,
-                                 &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT8_Marshal(disable, ctx->cmdBuffer,
+                                 ctx->maxCmdSize,
+                                 &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ClearControl(
@@ -68,11 +69,12 @@ TSS2_RC Tss2_Sys_ClearControl(
     TPMI_YES_NO disable,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ClearControl_Prepare(sysContext, auth, disable);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_ClockRateAdjust.c
+++ b/sysapi/sysapi/Tss2_Sys_ClockRateAdjust.c
@@ -33,31 +33,32 @@ TSS2_RC Tss2_Sys_ClockRateAdjust_Prepare(
     TPMI_RH_PROVISION auth,
     TPM2_CLOCK_ADJUST rateAdjust)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ClockRateAdjust);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ClockRateAdjust);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(auth, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(rateAdjust, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(rateAdjust, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ClockRateAdjust(
@@ -67,11 +68,12 @@ TSS2_RC Tss2_Sys_ClockRateAdjust(
     TPM2_CLOCK_ADJUST rateAdjust,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ClockRateAdjust_Prepare(sysContext, auth, rateAdjust);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_ClockSet.c
+++ b/sysapi/sysapi/Tss2_Sys_ClockSet.c
@@ -33,31 +33,32 @@ TSS2_RC Tss2_Sys_ClockSet_Prepare(
     TPMI_RH_PROVISION auth,
     UINT64 newTime)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ClockSet);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ClockSet);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(auth, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT64_Marshal(newTime, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT64_Marshal(newTime, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ClockSet(
@@ -67,11 +68,12 @@ TSS2_RC Tss2_Sys_ClockSet(
     UINT64 newTime,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ClockSet_Prepare(sysContext, auth, newTime);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_Commit.c
+++ b/sysapi/sysapi/Tss2_Sys_Commit.c
@@ -31,57 +31,58 @@
 TSS2_RC Tss2_Sys_Commit_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT signHandle,
-    const TPM2B_ECC_POINT	*P1,
-    const TPM2B_SENSITIVE_DATA	*s2,
-    const TPM2B_ECC_PARAMETER	*y2)
+    const TPM2B_ECC_POINT *P1,
+    const TPM2B_SENSITIVE_DATA *s2,
+    const TPM2B_ECC_PARAMETER *y2)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Commit);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Commit);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(signHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!P1) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
-        rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(P1, SYS_CONTEXT->cmdBuffer,
-                                               SYS_CONTEXT->maxCmdSize,
-                                               &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(P1, ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(s2, SYS_CONTEXT->cmdBuffer,
-                                                SYS_CONTEXT->maxCmdSize,
-                                                &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(s2, ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData);
     if (rval)
         return rval;
 
-    Tss2_MU_TPM2B_ECC_PARAMETER_Marshal(y2, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    Tss2_MU_TPM2B_ECC_PARAMETER_Marshal(y2, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Commit_Complete(
@@ -91,58 +92,60 @@ TSS2_RC Tss2_Sys_Commit_Complete(
     TPM2B_ECC_POINT *E,
     UINT16 *counter)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData, K);
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData, K);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData, L);
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData, L);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData, E);
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData, E);
     if (rval)
         return rval;
 
-    return Tss2_MU_UINT16_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData, counter);
+    return Tss2_MU_UINT16_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData, counter);
 }
 
 TSS2_RC Tss2_Sys_Commit(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT signHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_ECC_POINT	*P1,
-    const TPM2B_SENSITIVE_DATA	*s2,
-    const TPM2B_ECC_PARAMETER	*y2,
+    const TPM2B_ECC_POINT *P1,
+    const TPM2B_SENSITIVE_DATA *s2,
+    const TPM2B_ECC_PARAMETER *y2,
     TPM2B_ECC_POINT *K,
     TPM2B_ECC_POINT *L,
     TPM2B_ECC_POINT *E,
     UINT16 *counter,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_Commit_Prepare(sysContext, signHandle, P1, s2, y2);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_ContextLoad.c
+++ b/sysapi/sysapi/Tss2_Sys_ContextLoad.c
@@ -30,54 +30,57 @@
 
 TSS2_RC Tss2_Sys_ContextLoad_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
-    const TPMS_CONTEXT	*context)
+    const TPMS_CONTEXT *context)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !context)
+    if (!ctx || !context)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ContextLoad);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ContextLoad);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMS_CONTEXT_Marshal(context, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMS_CONTEXT_Marshal(context, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 0;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 0;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ContextLoad_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_CONTEXT *loadedHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData,
                                     loadedHandle);
     if (rval)
         return rval;
 
-    return CommonComplete(sysContext);
+    return CommonComplete(ctx);
 }
 
 TSS2_RC Tss2_Sys_ContextLoad(
     TSS2_SYS_CONTEXT *sysContext,
-    const TPMS_CONTEXT	*context,
+    const TPMS_CONTEXT *context,
     TPMI_DH_CONTEXT *loadedHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!context)
@@ -87,7 +90,7 @@ TSS2_RC Tss2_Sys_ContextLoad(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, 0, 0);
+    rval = CommonOneCall(ctx, 0, 0);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_ContextSave.c
+++ b/sysapi/sysapi/Tss2_Sys_ContextSave.c
@@ -32,43 +32,46 @@ TSS2_RC Tss2_Sys_ContextSave_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_CONTEXT saveHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
-    if (!sysContext)
+
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ContextSave);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ContextSave);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(saveHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(saveHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 0;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 0;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ContextSave_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMS_CONTEXT *context)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMS_CONTEXT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPMS_CONTEXT_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           context);
 }
 
@@ -77,13 +80,14 @@ TSS2_RC Tss2_Sys_ContextSave(
     TPMI_DH_CONTEXT saveHandle,
     TPMS_CONTEXT *context)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ContextSave_Prepare(sysContext, saveHandle);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, 0, 0);
+    rval = CommonOneCall(ctx, 0, 0);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_Create.c
+++ b/sysapi/sysapi/Tss2_Sys_Create.c
@@ -31,67 +31,68 @@
 TSS2_RC Tss2_Sys_Create_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT parentHandle,
-    const TPM2B_SENSITIVE_CREATE	*inSensitive,
-    const TPM2B_PUBLIC	*inPublic,
-    const TPM2B_DATA	*outsideInfo,
-    const TPML_PCR_SELECTION	*creationPCR)
+    const TPM2B_SENSITIVE_CREATE *inSensitive,
+    const TPM2B_PUBLIC *inPublic,
+    const TPM2B_DATA *outsideInfo,
+    const TPML_PCR_SELECTION *creationPCR)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !creationPCR)
+    if (!ctx || !creationPCR)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Create);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Create);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(parentHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!inSensitive) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
         rval = Tss2_MU_TPM2B_SENSITIVE_CREATE_Marshal(inSensitive,
-                                                      SYS_CONTEXT->cmdBuffer,
-                                                      SYS_CONTEXT->maxCmdSize,
-                                                      &SYS_CONTEXT->nextData);
+                                                      ctx->cmdBuffer,
+                                                      ctx->maxCmdSize,
+                                                      &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(creationPCR,
-                                              SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData);
+                                              ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Create_Complete(
@@ -102,46 +103,47 @@ TSS2_RC Tss2_Sys_Create_Complete(
     TPM2B_DIGEST *creationHash,
     TPMT_TK_CREATION *creationTicket)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData,
                                            outPrivate);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           outPublic);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_CREATION_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                 SYS_CONTEXT->maxCmdSize,
-                                                 &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_CREATION_DATA_Unmarshal(ctx->cmdBuffer,
+                                                 ctx->maxCmdSize,
+                                                 &ctx->nextData,
                                                  creationData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           creationHash);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_CREATION_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPMT_TK_CREATION_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           creationTicket);
 }
 
@@ -149,10 +151,10 @@ TSS2_RC Tss2_Sys_Create(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT parentHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_SENSITIVE_CREATE	*inSensitive,
-    const TPM2B_PUBLIC	*inPublic,
-    const TPM2B_DATA	*outsideInfo,
-    const TPML_PCR_SELECTION	*creationPCR,
+    const TPM2B_SENSITIVE_CREATE *inSensitive,
+    const TPM2B_PUBLIC *inPublic,
+    const TPM2B_DATA *outsideInfo,
+    const TPML_PCR_SELECTION *creationPCR,
     TPM2B_PRIVATE *outPrivate,
     TPM2B_PUBLIC *outPublic,
     TPM2B_CREATION_DATA *creationData,
@@ -160,6 +162,7 @@ TSS2_RC Tss2_Sys_Create(
     TPMT_TK_CREATION *creationTicket,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!creationPCR)
@@ -170,7 +173,7 @@ TSS2_RC Tss2_Sys_Create(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_CreatePrimary.c
+++ b/sysapi/sysapi/Tss2_Sys_CreatePrimary.c
@@ -31,69 +31,70 @@
 TSS2_RC Tss2_Sys_CreatePrimary_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY primaryHandle,
-    const TPM2B_SENSITIVE_CREATE	*inSensitive,
-    const TPM2B_PUBLIC	*inPublic,
-    const TPM2B_DATA	*outsideInfo,
-    const TPML_PCR_SELECTION	*creationPCR)
+    const TPM2B_SENSITIVE_CREATE *inSensitive,
+    const TPM2B_PUBLIC *inPublic,
+    const TPM2B_DATA *outsideInfo,
+    const TPML_PCR_SELECTION *creationPCR)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
     if (!creationPCR)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_CreatePrimary);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_CreatePrimary);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(primaryHandle, SYS_CONTEXT->cmdBuffer,
-                          SYS_CONTEXT->maxCmdSize,
-                          &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(primaryHandle, ctx->cmdBuffer,
+                          ctx->maxCmdSize,
+                          &ctx->nextData);
     if (rval)
         return rval;
 
     if (!inSensitive) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
         rval = Tss2_MU_TPM2B_SENSITIVE_CREATE_Marshal(inSensitive,
-                                                      SYS_CONTEXT->cmdBuffer,
-                                                      SYS_CONTEXT->maxCmdSize,
-                                                      &SYS_CONTEXT->nextData);
+                                                      ctx->cmdBuffer,
+                                                      ctx->maxCmdSize,
+                                                      &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_DATA_Marshal(outsideInfo, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(creationPCR,
-                                              SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData);
+                                              ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    rval = CommonPrepareEpilogue(sysContext);
+    rval = CommonPrepareEpilogue(ctx);
     return rval;
 }
 
@@ -106,51 +107,52 @@ TSS2_RC Tss2_Sys_CreatePrimary_Complete(
     TPMT_TK_CREATION *creationTicket,
     TPM2B_NAME *name)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData, objectHandle);
+    rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData, objectHandle);
     if (rval)
         return rval;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData, outPublic);
+    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData, outPublic);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_CREATION_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                 SYS_CONTEXT->maxCmdSize,
-                                                 &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_CREATION_DATA_Unmarshal(ctx->cmdBuffer,
+                                                 ctx->maxCmdSize,
+                                                 &ctx->nextData,
                                                  creationData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           creationHash);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_TK_CREATION_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPMT_TK_CREATION_Unmarshal(ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData,
                                               creationTicket);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData, name);
+    rval = Tss2_MU_TPM2B_NAME_Unmarshal(ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData, name);
     return rval;
 }
 
@@ -158,10 +160,10 @@ TSS2_RC Tss2_Sys_CreatePrimary(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY primaryHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_SENSITIVE_CREATE	*inSensitive,
-    const TPM2B_PUBLIC	*inPublic,
-    const TPM2B_DATA	*outsideInfo,
-    const TPML_PCR_SELECTION	*creationPCR,
+    const TPM2B_SENSITIVE_CREATE *inSensitive,
+    const TPM2B_PUBLIC *inPublic,
+    const TPM2B_DATA *outsideInfo,
+    const TPML_PCR_SELECTION *creationPCR,
     TPM2_HANDLE *objectHandle,
     TPM2B_PUBLIC *outPublic,
     TPM2B_CREATION_DATA *creationData,
@@ -170,9 +172,10 @@ TSS2_RC Tss2_Sys_CreatePrimary(
     TPM2B_NAME *name,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !creationPCR)
+    if (!ctx || !creationPCR)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
     rval = Tss2_Sys_CreatePrimary_Prepare(sysContext, primaryHandle, inSensitive,
@@ -180,7 +183,7 @@ TSS2_RC Tss2_Sys_CreatePrimary(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
 
     if (rval)
         return rval;

--- a/sysapi/sysapi/Tss2_Sys_DictionaryAttackLockReset.c
+++ b/sysapi/sysapi/Tss2_Sys_DictionaryAttackLockReset.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_DictionaryAttackLockReset_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_LOCKOUT lockHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_DictionaryAttackLockReset);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_DictionaryAttackLockReset);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(lockHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(lockHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_DictionaryAttackLockReset(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_DictionaryAttackLockReset(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_DictionaryAttackLockReset_Prepare(sysContext, lockHandle);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_DictionaryAttackParameters.c
+++ b/sysapi/sysapi/Tss2_Sys_DictionaryAttackParameters.c
@@ -35,43 +35,44 @@ TSS2_RC Tss2_Sys_DictionaryAttackParameters_Prepare(
     UINT32 newRecoveryTime,
     UINT32 lockoutRecovery)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_DictionaryAttackParameters);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_DictionaryAttackParameters);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(lockHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(lockHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
 
-    rval = Tss2_MU_UINT32_Marshal(newMaxTries, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(newMaxTries, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(newRecoveryTime, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(newRecoveryTime, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(lockoutRecovery, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(lockoutRecovery, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_DictionaryAttackParameters(
@@ -83,6 +84,7 @@ TSS2_RC Tss2_Sys_DictionaryAttackParameters(
     UINT32 lockoutRecovery,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
     rval = Tss2_Sys_DictionaryAttackParameters_Prepare(sysContext, lockHandle,
                                                        newMaxTries, newRecoveryTime,
@@ -90,5 +92,5 @@ TSS2_RC Tss2_Sys_DictionaryAttackParameters(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_Duplicate.c
+++ b/sysapi/sysapi/Tss2_Sys_Duplicate.c
@@ -32,58 +32,59 @@ TSS2_RC Tss2_Sys_Duplicate_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT objectHandle,
     TPMI_DH_OBJECT newParentHandle,
-    const TPM2B_DATA	*encryptionKeyIn,
-    const TPMT_SYM_DEF_OBJECT	*symmetricAlg)
+    const TPM2B_DATA *encryptionKeyIn,
+    const TPMT_SYM_DEF_OBJECT *symmetricAlg)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !symmetricAlg)
+    if (!ctx || !symmetricAlg)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Duplicate);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Duplicate);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(newParentHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(newParentHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!encryptionKeyIn) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(encryptionKeyIn, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DATA_Marshal(encryptionKeyIn, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPMT_SYM_DEF_OBJECT_Marshal(symmetricAlg,
-                                               SYS_CONTEXT->cmdBuffer,
-                                               SYS_CONTEXT->maxCmdSize,
-                                               &SYS_CONTEXT->nextData);
+                                               ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Duplicate_Complete(
@@ -92,32 +93,33 @@ TSS2_RC Tss2_Sys_Duplicate_Complete(
     TPM2B_PRIVATE *duplicate,
     TPM2B_ENCRYPTED_SECRET *outSymSeed)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_DATA_Unmarshal(ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData,
                                         encryptionKeyOut);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData,
                                            duplicate);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                    SYS_CONTEXT->maxCmdSize,
-                                                    &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(ctx->cmdBuffer,
+                                                    ctx->maxCmdSize,
+                                                    &ctx->nextData,
                                                     outSymSeed);
 }
 
@@ -126,13 +128,14 @@ TSS2_RC Tss2_Sys_Duplicate(
     TPMI_DH_OBJECT objectHandle,
     TPMI_DH_OBJECT newParentHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DATA	*encryptionKeyIn,
-    const TPMT_SYM_DEF_OBJECT	*symmetricAlg,
+    const TPM2B_DATA *encryptionKeyIn,
+    const TPMT_SYM_DEF_OBJECT *symmetricAlg,
     TPM2B_DATA *encryptionKeyOut,
     TPM2B_PRIVATE *duplicate,
     TPM2B_ENCRYPTED_SECRET *outSymSeed,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!symmetricAlg)
@@ -144,7 +147,7 @@ TSS2_RC Tss2_Sys_Duplicate(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_ECC_Parameters.c
+++ b/sysapi/sysapi/Tss2_Sys_ECC_Parameters.c
@@ -32,44 +32,46 @@ TSS2_RC Tss2_Sys_ECC_Parameters_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_ECC_CURVE curveID)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ECC_Parameters);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ECC_Parameters);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(curveID, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(curveID, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ECC_Parameters_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMS_ALGORITHM_DETAIL_ECC *parameters)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMS_ALGORITHM_DETAIL_ECC_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                       SYS_CONTEXT->maxCmdSize,
-                                                       &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPMS_ALGORITHM_DETAIL_ECC_Unmarshal(ctx->cmdBuffer,
+                                                       ctx->maxCmdSize,
+                                                       &ctx->nextData,
                                                        parameters);
 }
 
@@ -80,13 +82,14 @@ TSS2_RC Tss2_Sys_ECC_Parameters(
     TPMS_ALGORITHM_DETAIL_ECC *parameters,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ECC_Parameters_Prepare(sysContext, curveID);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_ECDH_KeyGen.c
+++ b/sysapi/sysapi/Tss2_Sys_ECDH_KeyGen.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_ECDH_KeyGen_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ECDH_KeyGen);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ECDH_KeyGen);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ECDH_KeyGen_Complete(
@@ -59,25 +60,26 @@ TSS2_RC Tss2_Sys_ECDH_KeyGen_Complete(
     TPM2B_ECC_POINT *zPoint,
     TPM2B_ECC_POINT *pubPoint)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData,
                                              zPoint);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData,
                                              pubPoint);
 }
 
@@ -89,13 +91,14 @@ TSS2_RC Tss2_Sys_ECDH_KeyGen(
     TPM2B_ECC_POINT *pubPoint,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ECDH_KeyGen_Prepare(sysContext, keyHandle);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_ECDH_ZGen.c
+++ b/sysapi/sysapi/Tss2_Sys_ECDH_ZGen.c
@@ -31,70 +31,73 @@
 TSS2_RC Tss2_Sys_ECDH_ZGen_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    const TPM2B_ECC_POINT	*inPoint)
+    const TPM2B_ECC_POINT *inPoint)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ECDH_ZGen);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ECDH_ZGen);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inPoint, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inPoint, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ECDH_ZGen_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_ECC_POINT *outPoint)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
-                                          outPoint);
+    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData,
+                                             outPoint);
 }
 
 TSS2_RC Tss2_Sys_ECDH_ZGen(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_ECC_POINT	*inPoint,
+    const TPM2B_ECC_POINT *inPoint,
     TPM2B_ECC_POINT *outPoint,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ECDH_ZGen_Prepare(sysContext, keyHandle, inPoint);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_EC_Ephemeral.c
+++ b/sysapi/sysapi/Tss2_Sys_EC_Ephemeral.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_EC_Ephemeral_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_ECC_CURVE curveID)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_EC_Ephemeral);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_EC_Ephemeral);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(curveID, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(curveID, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_EC_Ephemeral_Complete(
@@ -59,23 +60,24 @@ TSS2_RC Tss2_Sys_EC_Ephemeral_Complete(
     TPM2B_ECC_POINT *Q,
     UINT16 *counter)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData, Q);
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData, Q);
     if (rval)
         return rval;
 
-    return Tss2_MU_UINT16_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData, counter);
+    return Tss2_MU_UINT16_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData, counter);
 }
 
 TSS2_RC Tss2_Sys_EC_Ephemeral(
@@ -86,13 +88,14 @@ TSS2_RC Tss2_Sys_EC_Ephemeral(
     UINT16 *counter,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_EC_Ephemeral_Prepare(sysContext, curveID);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_EncryptDecrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_EncryptDecrypt.c
@@ -33,53 +33,54 @@ TSS2_RC Tss2_Sys_EncryptDecrypt_Prepare(
     TPMI_DH_OBJECT keyHandle,
     TPMI_YES_NO decrypt,
     TPMI_ALG_SYM_MODE mode,
-    const TPM2B_IV	*ivIn,
-    const TPM2B_MAX_BUFFER	*inData)
+    const TPM2B_IV *ivIn,
+    const TPM2B_MAX_BUFFER *inData)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_EncryptDecrypt);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_EncryptDecrypt);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(decrypt, SYS_CONTEXT->cmdBuffer,
-                                 SYS_CONTEXT->maxCmdSize,
-                                 &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT8_Marshal(decrypt, ctx->cmdBuffer,
+                                 ctx->maxCmdSize,
+                                 &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(mode, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(mode, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_IV_Marshal(ivIn, SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_IV_Marshal(ivIn, ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(inData, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(inData, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_EncryptDecrypt_Complete(
@@ -87,25 +88,26 @@ TSS2_RC Tss2_Sys_EncryptDecrypt_Complete(
     TPM2B_MAX_BUFFER *outData,
     TPM2B_IV *ivOut)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData,
                                               outData);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_IV_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_IV_Unmarshal(ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData,
                                       ivOut);
 }
 
@@ -115,12 +117,13 @@ TSS2_RC Tss2_Sys_EncryptDecrypt(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPMI_YES_NO decrypt,
     TPMI_ALG_SYM_MODE mode,
-    const TPM2B_IV	*ivIn,
-    const TPM2B_MAX_BUFFER	*inData,
+    const TPM2B_IV *ivIn,
+    const TPM2B_MAX_BUFFER *inData,
     TPM2B_MAX_BUFFER *outData,
     TPM2B_IV *ivOut,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_EncryptDecrypt_Prepare(sysContext, keyHandle, decrypt,
@@ -128,7 +131,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_EncryptDecrypt2.c
+++ b/sysapi/sysapi/Tss2_Sys_EncryptDecrypt2.c
@@ -36,55 +36,56 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2_Prepare (
     TPMI_ALG_SYM_MODE mode,
     const TPM2B_IV *ivIn)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue (sysContext, TPM2_CC_EncryptDecrypt2);
+    rval = CommonPreparePrologue (ctx, TPM2_CC_EncryptDecrypt2);
     if (rval)
         return rval;
 
     rval = Tss2_MU_UINT32_Marshal (keyHandle,
-                                   SYS_CONTEXT->cmdBuffer,
-                                   SYS_CONTEXT->maxCmdSize,
-                                   &SYS_CONTEXT->nextData);
+                                   ctx->cmdBuffer,
+                                   ctx->maxCmdSize,
+                                   &ctx->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal (inData,
-                                             SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData);
+                                             ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_UINT8_Marshal (decrypt,
-                                  SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+                                  ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_UINT16_Marshal (mode,
-                                   SYS_CONTEXT->cmdBuffer,
-                                   SYS_CONTEXT->maxCmdSize,
-                                   &SYS_CONTEXT->nextData);
+                                   ctx->cmdBuffer,
+                                   ctx->maxCmdSize,
+                                   &ctx->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPM2B_IV_Marshal (ivIn,
-                                     SYS_CONTEXT->cmdBuffer,
-                                     SYS_CONTEXT->maxCmdSize,
-                                     &SYS_CONTEXT->nextData);
+                                     ctx->cmdBuffer,
+                                     ctx->maxCmdSize,
+                                     &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue (sysContext);
+    return CommonPrepareEpilogue (ctx);
 }
 
 TSS2_RC Tss2_Sys_EncryptDecrypt2_Complete (
@@ -92,25 +93,26 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2_Complete (
     TPM2B_MAX_BUFFER *outData,
     TPM2B_IV *ivOut)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete (sysContext);
+    rval = CommonComplete (ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal (SYS_CONTEXT->cmdBuffer,
-                                               SYS_CONTEXT->maxCmdSize,
-                                               &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal (ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData,
                                                outData);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_IV_Unmarshal (SYS_CONTEXT->cmdBuffer,
-                                       SYS_CONTEXT->maxCmdSize,
-                                       &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_IV_Unmarshal (ctx->cmdBuffer,
+                                       ctx->maxCmdSize,
+                                       &ctx->nextData,
                                        ivOut);
 }
 
@@ -126,6 +128,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2 (
     TPM2B_IV *ivOut,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_EncryptDecrypt2_Prepare (sysContext,
@@ -137,7 +140,7 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2 (
     if (rval)
         return rval;
 
-    rval = CommonOneCall (sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall (ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_EventSequenceComplete.c
+++ b/sysapi/sysapi/Tss2_Sys_EventSequenceComplete.c
@@ -32,58 +32,60 @@ TSS2_RC Tss2_Sys_EventSequenceComplete_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
     TPMI_DH_OBJECT sequenceHandle,
-    const TPM2B_MAX_BUFFER	*buffer)
+    const TPM2B_MAX_BUFFER *buffer)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_EventSequenceComplete);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_EventSequenceComplete);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(pcrHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_EventSequenceComplete_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPML_DIGEST_VALUES *results)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPML_DIGEST_VALUES_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                SYS_CONTEXT->maxCmdSize,
-                                                &SYS_CONTEXT->nextData, results);
+    return Tss2_MU_TPML_DIGEST_VALUES_Unmarshal(ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData, results);
 }
 
 TSS2_RC Tss2_Sys_EventSequenceComplete(
@@ -91,10 +93,11 @@ TSS2_RC Tss2_Sys_EventSequenceComplete(
     TPMI_DH_PCR pcrHandle,
     TPMI_DH_OBJECT sequenceHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_MAX_BUFFER	*buffer,
+    const TPM2B_MAX_BUFFER *buffer,
     TPML_DIGEST_VALUES *results,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_EventSequenceComplete_Prepare(sysContext, pcrHandle,
@@ -102,7 +105,7 @@ TSS2_RC Tss2_Sys_EventSequenceComplete(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_EvictControl.c
+++ b/sysapi/sysapi/Tss2_Sys_EvictControl.c
@@ -34,36 +34,37 @@ TSS2_RC Tss2_Sys_EvictControl_Prepare(
     TPMI_DH_OBJECT objectHandle,
     TPMI_DH_PERSISTENT persistentHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_EvictControl);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_EvictControl);
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(auth, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(persistentHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(persistentHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_EvictControl(
@@ -74,6 +75,7 @@ TSS2_RC Tss2_Sys_EvictControl(
     TPMI_DH_PERSISTENT persistentHandle,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_EvictControl_Prepare(sysContext, auth, objectHandle,
@@ -81,6 +83,6 @@ TSS2_RC Tss2_Sys_EvictControl(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray,
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray,
                                           rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_FieldUpgradeData.c
+++ b/sysapi/sysapi/Tss2_Sys_FieldUpgradeData.c
@@ -32,27 +32,28 @@ TSS2_RC Tss2_Sys_FieldUpgradeData_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_MAX_BUFFER *fuData)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_FieldUpgradeData);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_FieldUpgradeData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(fuData,
-                                            SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+                                            ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_FieldUpgradeData_Complete(
@@ -60,25 +61,26 @@ TSS2_RC Tss2_Sys_FieldUpgradeData_Complete(
     TPMT_HA *nextDigest,
     TPMT_HA *firstDigest)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_HA_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                     SYS_CONTEXT->maxCmdSize,
-                                     &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPMT_HA_Unmarshal(ctx->cmdBuffer,
+                                     ctx->maxCmdSize,
+                                     &ctx->nextData,
                                      nextDigest);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_HA_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                     SYS_CONTEXT->maxCmdSize,
-                                     &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPMT_HA_Unmarshal(ctx->cmdBuffer,
+                                     ctx->maxCmdSize,
+                                     &ctx->nextData,
                                      firstDigest);
 }
 
@@ -90,13 +92,14 @@ TSS2_RC Tss2_Sys_FieldUpgradeData(
     TPMT_HA *firstDigest,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_FieldUpgradeData_Prepare(sysContext, fuData);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_FieldUpgradeStart.c
+++ b/sysapi/sysapi/Tss2_Sys_FieldUpgradeStart.c
@@ -35,54 +35,55 @@ TSS2_RC Tss2_Sys_FieldUpgradeStart_Prepare(
     TPM2B_DIGEST *fuDigest,
     TPMT_SIGNATURE *manifestSignature)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !manifestSignature)
+    if (!ctx || !manifestSignature)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_FieldUpgradeStart);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_FieldUpgradeStart);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(authorization, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authorization, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!fuDigest) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(fuDigest, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(fuDigest, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPMT_SIGNATURE_Marshal(manifestSignature,
-                                          SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+                                          ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_FieldUpgradeStart(
@@ -94,14 +95,17 @@ TSS2_RC Tss2_Sys_FieldUpgradeStart(
     TPMT_SIGNATURE *manifestSignature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!manifestSignature)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_Sys_FieldUpgradeStart_Prepare(sysContext, authorization, keyHandle, fuDigest, manifestSignature);
+    rval = Tss2_Sys_FieldUpgradeStart_Prepare(sysContext, authorization,
+                                              keyHandle, fuDigest,
+                                              manifestSignature);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_FirmwareRead.c
+++ b/sysapi/sysapi/Tss2_Sys_FirmwareRead.c
@@ -32,44 +32,46 @@ TSS2_RC Tss2_Sys_FirmwareRead_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     UINT32 sequenceNumber)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_FirmwareRead);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_FirmwareRead);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sequenceNumber, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(sequenceNumber, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_FirmwareRead_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_MAX_BUFFER *fuData)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData, fuData);
+    return Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData, fuData);
 }
 
 TSS2_RC Tss2_Sys_FirmwareRead(
@@ -79,13 +81,14 @@ TSS2_RC Tss2_Sys_FirmwareRead(
     TPM2B_MAX_BUFFER *fuData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_FirmwareRead_Prepare(sysContext, sequenceNumber);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_FlushContext.c
+++ b/sysapi/sysapi/Tss2_Sys_FlushContext.c
@@ -32,37 +32,38 @@ TSS2_RC Tss2_Sys_FlushContext_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_CONTEXT flushHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_FlushContext);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_FlushContext);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT32_Marshal(flushHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(flushHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 0;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 0;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_FlushContext(
     TSS2_SYS_CONTEXT *sysContext,
-    TPMI_DH_CONTEXT    flushHandle
-    )
+    TPMI_DH_CONTEXT flushHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_FlushContext_Prepare(sysContext, flushHandle);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, 0, 0);
+    return CommonOneCallForNoResponseCmds(ctx, 0, 0);
 }

--- a/sysapi/sysapi/Tss2_Sys_GetCapability.c
+++ b/sysapi/sysapi/Tss2_Sys_GetCapability.c
@@ -34,38 +34,39 @@ TSS2_RC Tss2_Sys_GetCapability_Prepare(
     UINT32 property,
     UINT32 propertyCount)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_GetCapability);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_GetCapability);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(capability, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(capability, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(property, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(property, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(propertyCount, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(propertyCount, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_GetCapability_Complete(
@@ -73,25 +74,26 @@ TSS2_RC Tss2_Sys_GetCapability_Complete(
     TPMI_YES_NO *moreData,
     TPMS_CAPABILITY_DATA *capabilityData)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                   SYS_CONTEXT->maxCmdSize,
-                                   &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_UINT8_Unmarshal(ctx->cmdBuffer,
+                                   ctx->maxCmdSize,
+                                   &ctx->nextData,
                                    moreData);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMS_CAPABILITY_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                  SYS_CONTEXT->maxCmdSize,
-                                                  &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPMS_CAPABILITY_DATA_Unmarshal(ctx->cmdBuffer,
+                                                  ctx->maxCmdSize,
+                                                  &ctx->nextData,
                                                   capabilityData);
 }
 
@@ -105,6 +107,7 @@ TSS2_RC Tss2_Sys_GetCapability(
     TPMS_CAPABILITY_DATA *capabilityData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_GetCapability_Prepare(sysContext, capability, property,
@@ -112,7 +115,7 @@ TSS2_RC Tss2_Sys_GetCapability(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_GetCommandAuditDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_GetCommandAuditDigest.c
@@ -32,57 +32,58 @@ TSS2_RC Tss2_Sys_GetCommandAuditDigest_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_ENDORSEMENT privacyHandle,
     TPMI_DH_OBJECT signHandle,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme)
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !inScheme)
+    if (!ctx || !inScheme)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_GetCommandAuditDigest);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_GetCommandAuditDigest);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(privacyHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(privacyHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(signHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!qualifyingData) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_GetCommandAuditDigest_Complete(
@@ -90,24 +91,25 @@ TSS2_RC Tss2_Sys_GetCommandAuditDigest_Complete(
     TPM2B_ATTEST *auditInfo,
     TPMT_SIGNATURE *signature)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData, auditInfo);
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData, auditInfo);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData, signature);
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData, signature);
 }
 
 TSS2_RC Tss2_Sys_GetCommandAuditDigest(
@@ -115,12 +117,13 @@ TSS2_RC Tss2_Sys_GetCommandAuditDigest(
     TPMI_RH_ENDORSEMENT privacyHandle,
     TPMI_DH_OBJECT signHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme,
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme,
     TPM2B_ATTEST *auditInfo,
     TPMT_SIGNATURE *signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!inScheme)
@@ -132,7 +135,7 @@ TSS2_RC Tss2_Sys_GetCommandAuditDigest(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_GetRandom.c
+++ b/sysapi/sysapi/Tss2_Sys_GetRandom.c
@@ -32,43 +32,45 @@ TSS2_RC Tss2_Sys_GetRandom_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     UINT16 bytesRequested)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_GetRandom);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_GetRandom);
     if (rval)
         return rval;
-    rval = Tss2_MU_UINT16_Marshal(bytesRequested, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(bytesRequested, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_GetRandom_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_DIGEST *randomBytes)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData, randomBytes);
+    return Tss2_MU_TPM2B_DIGEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData, randomBytes);
 }
 
 TSS2_RC Tss2_Sys_GetRandom(
@@ -78,13 +80,14 @@ TSS2_RC Tss2_Sys_GetRandom(
     TPM2B_DIGEST *randomBytes,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_GetRandom_Prepare(sysContext, bytesRequested);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_GetSessionAuditDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_GetSessionAuditDigest.c
@@ -33,63 +33,64 @@ TSS2_RC Tss2_Sys_GetSessionAuditDigest_Prepare(
     TPMI_RH_ENDORSEMENT privacyAdminHandle,
     TPMI_DH_OBJECT signHandle,
     TPMI_SH_HMAC sessionHandle,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme)
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !inScheme)
+    if (!ctx || !inScheme)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_GetSessionAuditDigest);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_GetSessionAuditDigest);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(privacyAdminHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(privacyAdminHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(signHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sessionHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(sessionHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!qualifyingData) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_GetSessionAuditDigest_Complete(
@@ -97,24 +98,25 @@ TSS2_RC Tss2_Sys_GetSessionAuditDigest_Complete(
     TPM2B_ATTEST *auditInfo,
     TPMT_SIGNATURE *signature)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData, auditInfo);
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData, auditInfo);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData, signature);
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData, signature);
 }
 
 TSS2_RC Tss2_Sys_GetSessionAuditDigest(
@@ -123,12 +125,13 @@ TSS2_RC Tss2_Sys_GetSessionAuditDigest(
     TPMI_DH_OBJECT signHandle,
     TPMI_SH_HMAC sessionHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme,
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme,
     TPM2B_ATTEST *auditInfo,
     TPMT_SIGNATURE *signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!inScheme)
@@ -140,7 +143,7 @@ TSS2_RC Tss2_Sys_GetSessionAuditDigest(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_GetTestResult.c
+++ b/sysapi/sysapi/Tss2_Sys_GetTestResult.c
@@ -31,20 +31,21 @@
 TSS2_RC Tss2_Sys_GetTestResult_Prepare(
     TSS2_SYS_CONTEXT *sysContext)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_GetTestResult);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_GetTestResult);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_GetTestResult_Complete(
@@ -52,25 +53,26 @@ TSS2_RC Tss2_Sys_GetTestResult_Complete(
     TPM2B_MAX_BUFFER *outData,
     TSS2_RC *testResult)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Unmarshal(ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData,
                                               outData);
     if (rval)
         return rval;
 
-    return Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData,
+    return Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData,
                                     testResult);
 }
 
@@ -81,13 +83,14 @@ TSS2_RC Tss2_Sys_GetTestResult(
     TSS2_RC *testResult,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_GetTestResult_Prepare(sysContext);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_GetTime.c
+++ b/sysapi/sysapi/Tss2_Sys_GetTime.c
@@ -32,56 +32,57 @@ TSS2_RC Tss2_Sys_GetTime_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_ENDORSEMENT privacyAdminHandle,
     TPMI_DH_OBJECT signHandle,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme)
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !inScheme)
+    if (!ctx || !inScheme)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_GetTime);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_GetTime);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(privacyAdminHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(privacyAdminHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(signHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!qualifyingData) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_GetTime_Complete(
@@ -89,25 +90,26 @@ TSS2_RC Tss2_Sys_GetTime_Complete(
     TPM2B_ATTEST *timeInfo,
     TPMT_SIGNATURE *signature)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           timeInfo);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData,
                                             signature);
 }
 
@@ -116,12 +118,13 @@ TSS2_RC Tss2_Sys_GetTime(
     TPMI_RH_ENDORSEMENT privacyAdminHandle,
     TPMI_DH_OBJECT signHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme,
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme,
     TPM2B_ATTEST *timeInfo,
     TPMT_SIGNATURE *signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!inScheme)
@@ -132,7 +135,7 @@ TSS2_RC Tss2_Sys_GetTime(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_HMAC.c
+++ b/sysapi/sysapi/Tss2_Sys_HMAC.c
@@ -31,69 +31,71 @@
 TSS2_RC Tss2_Sys_HMAC_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT handle,
-    const TPM2B_MAX_BUFFER	*buffer,
+    const TPM2B_MAX_BUFFER *buffer,
     TPMI_ALG_HASH hashAlg)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_HMAC);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_HMAC);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(handle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(handle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!buffer) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->cmdBuffer,
-                                                SYS_CONTEXT->maxCmdSize,
-                                                &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_HMAC_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_DIGEST *outHMAC)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_DIGEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           outHMAC);
 }
 
@@ -101,18 +103,19 @@ TSS2_RC Tss2_Sys_HMAC(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT handle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_MAX_BUFFER	*buffer,
+    const TPM2B_MAX_BUFFER *buffer,
     TPMI_ALG_HASH hashAlg,
     TPM2B_DIGEST *outHMAC,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_HMAC_Prepare(sysContext, handle, buffer, hashAlg);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_HMAC_Start.c
+++ b/sysapi/sysapi/Tss2_Sys_HMAC_Start.c
@@ -31,89 +31,92 @@
 TSS2_RC Tss2_Sys_HMAC_Start_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT handle,
-    const TPM2B_AUTH	*auth,
+    const TPM2B_AUTH *auth,
     TPMI_ALG_HASH hashAlg)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_HMAC_Start);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_HMAC_Start);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(handle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(handle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!auth) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_HMAC_Start_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT *sequenceHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData,
                                     sequenceHandle);
     if (rval)
         return rval;
 
-    return CommonComplete(sysContext);
+    return CommonComplete(ctx);
 }
 
 TSS2_RC Tss2_Sys_HMAC_Start(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT handle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_AUTH	*auth,
+    const TPM2B_AUTH *auth,
     TPMI_ALG_HASH hashAlg,
     TPMI_DH_OBJECT *sequenceHandle,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_HMAC_Start_Prepare(sysContext, handle, auth, hashAlg);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_Hash.c
+++ b/sysapi/sysapi/Tss2_Sys_Hash.c
@@ -30,52 +30,53 @@
 
 TSS2_RC Tss2_Sys_Hash_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
-    const TPM2B_MAX_BUFFER	*data,
+    const TPM2B_MAX_BUFFER *data,
     TPMI_ALG_HASH hashAlg,
     TPMI_RH_HIERARCHY hierarchy)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Hash);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Hash);
     if (rval)
         return rval;
 
     if (!data) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(data, SYS_CONTEXT->cmdBuffer,
-                                                SYS_CONTEXT->maxCmdSize,
-                                                &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(data, ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(hierarchy, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(hierarchy, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Hash_Complete(
@@ -83,45 +84,47 @@ TSS2_RC Tss2_Sys_Hash_Complete(
     TPM2B_DIGEST *outHash,
     TPMT_TK_HASHCHECK *validation)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           outHash);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_HASHCHECK_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                               SYS_CONTEXT->maxCmdSize,
-                                               &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPMT_TK_HASHCHECK_Unmarshal(ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData,
                                                validation);
 }
 
 TSS2_RC Tss2_Sys_Hash(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_MAX_BUFFER	*data,
+    const TPM2B_MAX_BUFFER *data,
     TPMI_ALG_HASH hashAlg,
     TPMI_RH_HIERARCHY hierarchy,
     TPM2B_DIGEST *outHash,
     TPMT_TK_HASHCHECK *validation,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_Hash_Prepare(sysContext, data, hashAlg, hierarchy);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_HashSequenceStart.c
+++ b/sysapi/sysapi/Tss2_Sys_HashSequenceStart.c
@@ -30,81 +30,84 @@
 
 TSS2_RC Tss2_Sys_HashSequenceStart_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
-    const TPM2B_AUTH	*auth,
+    const TPM2B_AUTH *auth,
     TPMI_ALG_HASH hashAlg)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_HashSequenceStart);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_HashSequenceStart);
     if (rval)
         return rval;
 
     if (!auth) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_HashSequenceStart_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT *sequenceHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData,
                                     sequenceHandle);
     if (rval)
         return rval;
 
-    return CommonComplete(sysContext);
+    return CommonComplete(ctx);
 }
 
 TSS2_RC Tss2_Sys_HashSequenceStart(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_AUTH	*auth,
+    const TPM2B_AUTH *auth,
     TPMI_ALG_HASH hashAlg,
     TPMI_DH_OBJECT *sequenceHandle,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_HashSequenceStart_Prepare(sysContext, auth, hashAlg);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_HierarchyChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_HierarchyChangeAuth.c
@@ -31,48 +31,50 @@
 TSS2_RC Tss2_Sys_HierarchyChangeAuth_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY_AUTH authHandle,
-    const TPM2B_AUTH	*newAuth)
+    const TPM2B_AUTH *newAuth)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_HierarchyChangeAuth);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_HierarchyChangeAuth);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_HierarchyChangeAuth(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY_AUTH authHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_AUTH	*newAuth,
+    const TPM2B_AUTH *newAuth,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_HierarchyChangeAuth_Prepare(sysContext, authHandle, newAuth);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_HierarchyControl.c
+++ b/sysapi/sysapi/Tss2_Sys_HierarchyControl.c
@@ -34,38 +34,39 @@ TSS2_RC Tss2_Sys_HierarchyControl_Prepare(
     TPMI_RH_ENABLES enable,
     TPMI_YES_NO state)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_HierarchyControl);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_HierarchyControl);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(enable, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(enable, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(state, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT8_Marshal(state, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_HierarchyControl(
@@ -76,11 +77,12 @@ TSS2_RC Tss2_Sys_HierarchyControl(
     TPMI_YES_NO state,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_HierarchyControl_Prepare(sysContext, authHandle, enable, state);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_Import.c
+++ b/sysapi/sysapi/Tss2_Sys_Import.c
@@ -31,92 +31,94 @@
 TSS2_RC Tss2_Sys_Import_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT parentHandle,
-    const TPM2B_DATA	*encryptionKey,
-    const TPM2B_PUBLIC	*objectPublic,
-    const TPM2B_PRIVATE	*duplicate,
-    const TPM2B_ENCRYPTED_SECRET	*inSymSeed,
-    const TPMT_SYM_DEF_OBJECT	*symmetricAlg)
+    const TPM2B_DATA *encryptionKey,
+    const TPM2B_PUBLIC *objectPublic,
+    const TPM2B_PRIVATE *duplicate,
+    const TPM2B_ENCRYPTED_SECRET *inSymSeed,
+    const TPMT_SYM_DEF_OBJECT *symmetricAlg)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !symmetricAlg)
+    if (!ctx || !symmetricAlg)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Import);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Import);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(parentHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!encryptionKey) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(encryptionKey, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DATA_Marshal(encryptionKey, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(objectPublic, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(objectPublic, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PRIVATE_Marshal(duplicate, SYS_CONTEXT->cmdBuffer,
-                                         SYS_CONTEXT->maxCmdSize,
-                                         &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_PRIVATE_Marshal(duplicate, ctx->cmdBuffer,
+                                         ctx->maxCmdSize,
+                                         &ctx->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(inSymSeed,
-                                                  SYS_CONTEXT->cmdBuffer,
-                                                  SYS_CONTEXT->maxCmdSize,
-                                                  &SYS_CONTEXT->nextData);
+                                                  ctx->cmdBuffer,
+                                                  ctx->maxCmdSize,
+                                                  &ctx->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPMT_SYM_DEF_OBJECT_Marshal(symmetricAlg,
-                                               SYS_CONTEXT->cmdBuffer,
-                                               SYS_CONTEXT->maxCmdSize,
-                                               &SYS_CONTEXT->nextData);
+                                               ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Import_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_PRIVATE *outPrivate)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_PRIVATE_Unmarshal(ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData,
                                            outPrivate);
 }
 
@@ -124,14 +126,15 @@ TSS2_RC Tss2_Sys_Import(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT parentHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DATA	*encryptionKey,
-    const TPM2B_PUBLIC	*objectPublic,
-    const TPM2B_PRIVATE	*duplicate,
-    const TPM2B_ENCRYPTED_SECRET	*inSymSeed,
-    const TPMT_SYM_DEF_OBJECT	*symmetricAlg,
+    const TPM2B_DATA *encryptionKey,
+    const TPM2B_PUBLIC *objectPublic,
+    const TPM2B_PRIVATE *duplicate,
+    const TPM2B_ENCRYPTED_SECRET *inSymSeed,
+    const TPMT_SYM_DEF_OBJECT *symmetricAlg,
     TPM2B_PRIVATE *outPrivate,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!symmetricAlg)
@@ -143,7 +146,7 @@ TSS2_RC Tss2_Sys_Import(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_IncrementalSelfTest.c
+++ b/sysapi/sysapi/Tss2_Sys_IncrementalSelfTest.c
@@ -32,44 +32,46 @@ TSS2_RC Tss2_Sys_IncrementalSelfTest_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPML_ALG *toTest)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !toTest)
+    if (!ctx || !toTest)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_IncrementalSelfTest);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_IncrementalSelfTest);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_ALG_Marshal(toTest, SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPML_ALG_Marshal(toTest, ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_IncrementalSelfTest_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPML_ALG *toDoList)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPML_ALG_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData, toDoList);
+    return Tss2_MU_TPML_ALG_Unmarshal(ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData, toDoList);
 }
 
 TSS2_RC Tss2_Sys_IncrementalSelfTest(
@@ -79,6 +81,7 @@ TSS2_RC Tss2_Sys_IncrementalSelfTest(
     TPML_ALG *toDoList,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!toTest)
@@ -88,7 +91,7 @@ TSS2_RC Tss2_Sys_IncrementalSelfTest(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_Load.c
+++ b/sysapi/sysapi/Tss2_Sys_Load.c
@@ -31,51 +31,52 @@
 TSS2_RC Tss2_Sys_Load_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT parentHandle,
-    const TPM2B_PRIVATE	*inPrivate,
-    const TPM2B_PUBLIC	*inPublic)
+    const TPM2B_PRIVATE *inPrivate,
+    const TPM2B_PUBLIC *inPublic)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Load);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Load);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(parentHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!inPrivate) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_PRIVATE_Marshal(inPrivate, SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_PRIVATE_Marshal(inPrivate, ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Load_Complete(
@@ -83,43 +84,45 @@ TSS2_RC Tss2_Sys_Load_Complete(
     TPM2_HANDLE *objectHandle,
     TPM2B_NAME *name)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData, objectHandle);
+    rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData, objectHandle);
     if (rval)
         return rval;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData, name);
+    return Tss2_MU_TPM2B_NAME_Unmarshal(ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData, name);
 }
 
 TSS2_RC Tss2_Sys_Load(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT parentHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_PRIVATE	*inPrivate,
-    const TPM2B_PUBLIC	*inPublic,
+    const TPM2B_PRIVATE *inPrivate,
+    const TPM2B_PUBLIC *inPublic,
     TPM2_HANDLE *objectHandle,
     TPM2B_NAME *name,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_Load_Prepare(sysContext, parentHandle, inPrivate, inPublic);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_LoadExternal.c
+++ b/sysapi/sysapi/Tss2_Sys_LoadExternal.c
@@ -30,52 +30,53 @@
 
 TSS2_RC Tss2_Sys_LoadExternal_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
-    const TPM2B_SENSITIVE	*inPrivate,
-    const TPM2B_PUBLIC	*inPublic,
+    const TPM2B_SENSITIVE *inPrivate,
+    const TPM2B_PUBLIC *inPublic,
     TPMI_RH_HIERARCHY hierarchy)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_LoadExternal);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_LoadExternal);
 
     /* If no private key is specified, set the private key size field to 0 */
     if (!inPrivate) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
         rval = Tss2_MU_TPM2B_SENSITIVE_Marshal(inPrivate,
-                                               SYS_CONTEXT->cmdBuffer,
-                                               SYS_CONTEXT->maxCmdSize,
-                                               &SYS_CONTEXT->nextData);
+                                               ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-   rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, SYS_CONTEXT->cmdBuffer,
-                                       SYS_CONTEXT->maxCmdSize,
-                                       &SYS_CONTEXT->nextData);
+   rval = Tss2_MU_TPM2B_PUBLIC_Marshal(inPublic, ctx->cmdBuffer,
+                                       ctx->maxCmdSize,
+                                       &ctx->nextData);
     if (rval)
         return rval;
 
-   rval = Tss2_MU_UINT32_Marshal(hierarchy, SYS_CONTEXT->cmdBuffer,
-                                 SYS_CONTEXT->maxCmdSize,
-                                 &SYS_CONTEXT->nextData);
+   rval = Tss2_MU_UINT32_Marshal(hierarchy, ctx->cmdBuffer,
+                                 ctx->maxCmdSize,
+                                 &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_LoadExternal_Complete(
@@ -83,44 +84,46 @@ TSS2_RC Tss2_Sys_LoadExternal_Complete(
     TPM2_HANDLE *objectHandle,
     TPM2B_NAME *name)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData,
                                     objectHandle);
     if (rval)
         return rval;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData, name);
+    return Tss2_MU_TPM2B_NAME_Unmarshal(ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData, name);
 }
 
 TSS2_RC Tss2_Sys_LoadExternal(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_SENSITIVE	*inPrivate,
-    const TPM2B_PUBLIC	*inPublic,
+    const TPM2B_SENSITIVE *inPrivate,
+    const TPM2B_PUBLIC *inPublic,
     TPMI_RH_HIERARCHY hierarchy,
     TPM2_HANDLE *objectHandle,
     TPM2B_NAME *name,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_LoadExternal_Prepare(sysContext, inPrivate, inPublic, hierarchy);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_MakeCredential.c
+++ b/sysapi/sysapi/Tss2_Sys_MakeCredential.c
@@ -31,51 +31,52 @@
 TSS2_RC Tss2_Sys_MakeCredential_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT handle,
-    const TPM2B_DIGEST	*credential,
-    const TPM2B_NAME	*objectName)
+    const TPM2B_DIGEST *credential,
+    const TPM2B_NAME *objectName)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_MakeCredential);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_MakeCredential);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(handle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(handle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!credential) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(credential, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(credential, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(objectName, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_NAME_Marshal(objectName, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_MakeCredential_Complete(
@@ -83,25 +84,26 @@ TSS2_RC Tss2_Sys_MakeCredential_Complete(
     TPM2B_ID_OBJECT *credentialBlob,
     TPM2B_ENCRYPTED_SECRET *secret)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ID_OBJECT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_ID_OBJECT_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData,
                                              credentialBlob);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                    SYS_CONTEXT->maxCmdSize,
-                                                    &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(ctx->cmdBuffer,
+                                                    ctx->maxCmdSize,
+                                                    &ctx->nextData,
                                                     secret);
 }
 
@@ -109,19 +111,20 @@ TSS2_RC Tss2_Sys_MakeCredential(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT handle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DIGEST	*credential,
-    const TPM2B_NAME	*objectName,
+    const TPM2B_DIGEST *credential,
+    const TPM2B_NAME *objectName,
     TPM2B_ID_OBJECT *credentialBlob,
     TPM2B_ENCRYPTED_SECRET *secret,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_MakeCredential_Prepare(sysContext, handle, credential, objectName);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_NV_Certify.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Certify.c
@@ -33,77 +33,78 @@ TSS2_RC Tss2_Sys_NV_Certify_Prepare(
     TPMI_DH_OBJECT signHandle,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme,
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme,
     UINT16 size,
     UINT16 offset)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !inScheme)
+    if (!ctx || !inScheme)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_Certify);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_Certify);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(signHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!qualifyingData) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(size, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(size, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(offset, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_Certify_Complete(
@@ -111,25 +112,26 @@ TSS2_RC Tss2_Sys_NV_Certify_Complete(
     TPM2B_ATTEST *certifyInfo,
     TPMT_SIGNATURE *signature)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           certifyInfo);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData,
                                             signature);
 }
 
@@ -139,14 +141,15 @@ TSS2_RC Tss2_Sys_NV_Certify(
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme,
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme,
     UINT16 size,
     UINT16 offset,
     TPM2B_ATTEST *certifyInfo,
     TPMT_SIGNATURE *signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!inScheme)
@@ -158,7 +161,7 @@ TSS2_RC Tss2_Sys_NV_Certify(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_NV_ChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ChangeAuth.c
@@ -31,48 +31,50 @@
 TSS2_RC Tss2_Sys_NV_ChangeAuth_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX nvIndex,
-    const TPM2B_AUTH	*newAuth)
+    const TPM2B_AUTH *newAuth)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_ChangeAuth);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_ChangeAuth);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_ChangeAuth(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX nvIndex,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_AUTH	*newAuth,
+    const TPM2B_AUTH *newAuth,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_ChangeAuth_Prepare(sysContext, nvIndex, newAuth);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_DefineSpace.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_DefineSpace.c
@@ -31,66 +31,68 @@
 TSS2_RC Tss2_Sys_NV_DefineSpace_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION authHandle,
-    const TPM2B_AUTH	*auth,
-    const TPM2B_NV_PUBLIC	*publicInfo)
+    const TPM2B_AUTH *auth,
+    const TPM2B_NV_PUBLIC *publicInfo)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_DefineSpace);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_DefineSpace);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!auth) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_AUTH_Marshal(auth, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NV_PUBLIC_Marshal(publicInfo, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_NV_PUBLIC_Marshal(publicInfo, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_DefineSpace(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION authHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_AUTH	*auth,
-    const TPM2B_NV_PUBLIC	*publicInfo,
+    const TPM2B_AUTH *auth,
+    const TPM2B_NV_PUBLIC *publicInfo,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_DefineSpace_Prepare(sysContext, authHandle, auth, publicInfo);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_Extend.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Extend.c
@@ -32,40 +32,41 @@ TSS2_RC Tss2_Sys_NV_Extend_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    const TPM2B_MAX_NV_BUFFER	*data)
+    const TPM2B_MAX_NV_BUFFER *data)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_Extend);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_Extend);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_NV_BUFFER_Marshal(data, SYS_CONTEXT->cmdBuffer,
-                                               SYS_CONTEXT->maxCmdSize,
-                                               &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_MAX_NV_BUFFER_Marshal(data, ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_Extend(
@@ -73,14 +74,15 @@ TSS2_RC Tss2_Sys_NV_Extend(
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_MAX_NV_BUFFER	*data,
+    const TPM2B_MAX_NV_BUFFER *data,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_Extend_Prepare(sysContext, authHandle, nvIndex, data);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_GlobalWriteLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_GlobalWriteLock.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_NV_GlobalWriteLock_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION authHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_GlobalWriteLock);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_GlobalWriteLock);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_GlobalWriteLock(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_NV_GlobalWriteLock(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_GlobalWriteLock_Prepare(sysContext, authHandle);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_Increment.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Increment.c
@@ -33,32 +33,33 @@ TSS2_RC Tss2_Sys_NV_Increment_Prepare(
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_Increment);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_Increment);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_Increment(
@@ -68,11 +69,12 @@ TSS2_RC Tss2_Sys_NV_Increment(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_Increment_Prepare(sysContext, authHandle, nvIndex);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_Read.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Read.c
@@ -35,62 +35,64 @@ TSS2_RC Tss2_Sys_NV_Read_Prepare(
     UINT16 size,
     UINT16 offset)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_Read);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_Read);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(size, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(size, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(offset, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_Read_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_MAX_NV_BUFFER *data)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_MAX_NV_BUFFER_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                 SYS_CONTEXT->maxCmdSize,
-                                                 &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_MAX_NV_BUFFER_Unmarshal(ctx->cmdBuffer,
+                                                 ctx->maxCmdSize,
+                                                 &ctx->nextData,
                                                  data);
 }
 
@@ -104,13 +106,14 @@ TSS2_RC Tss2_Sys_NV_Read(
     TPM2B_MAX_NV_BUFFER *data,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_Read_Prepare(sysContext, authHandle, nvIndex, size, offset);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_NV_ReadLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ReadLock.c
@@ -33,32 +33,33 @@ TSS2_RC Tss2_Sys_NV_ReadLock_Prepare(
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_ReadLock);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_ReadLock);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_ReadLock(
@@ -68,11 +69,12 @@ TSS2_RC Tss2_Sys_NV_ReadLock(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_ReadLock_Prepare(sysContext, authHandle, nvIndex);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_ReadPublic.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ReadPublic.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_NV_ReadPublic_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX nvIndex)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_ReadPublic);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_ReadPublic);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_ReadPublic_Complete(
@@ -59,25 +60,26 @@ TSS2_RC Tss2_Sys_NV_ReadPublic_Complete(
     TPM2B_NV_PUBLIC *nvPublic,
     TPM2B_NAME *nvName)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NV_PUBLIC_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPM2B_NV_PUBLIC_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData,
                                              nvPublic);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_NAME_Unmarshal(ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData,
                                         nvName);
 }
 
@@ -89,13 +91,14 @@ TSS2_RC Tss2_Sys_NV_ReadPublic(
     TPM2B_NAME *nvName,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_ReadPublic_Prepare(sysContext, nvIndex);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_NV_SetBits.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_SetBits.c
@@ -34,38 +34,39 @@ TSS2_RC Tss2_Sys_NV_SetBits_Prepare(
     TPMI_RH_NV_INDEX nvIndex,
     UINT64 bits)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_SetBits);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_SetBits);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT64_Marshal(bits, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT64_Marshal(bits, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_SetBits(
@@ -76,11 +77,12 @@ TSS2_RC Tss2_Sys_NV_SetBits(
     UINT64 bits,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_SetBits_Prepare(sysContext, authHandle, nvIndex, bits);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_UndefineSpace.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_UndefineSpace.c
@@ -33,32 +33,33 @@ TSS2_RC Tss2_Sys_NV_UndefineSpace_Prepare(
     TPMI_RH_PROVISION authHandle,
     TPMI_RH_NV_INDEX nvIndex)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_UndefineSpace);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_UndefineSpace);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_UndefineSpace(
@@ -68,11 +69,12 @@ TSS2_RC Tss2_Sys_NV_UndefineSpace(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_UndefineSpace_Prepare(sysContext, authHandle, nvIndex);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_UndefineSpaceSpecial.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_UndefineSpaceSpecial.c
@@ -33,32 +33,33 @@ TSS2_RC Tss2_Sys_NV_UndefineSpaceSpecial_Prepare(
     TPMI_RH_NV_INDEX nvIndex,
     TPMI_RH_PLATFORM platform)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_UndefineSpaceSpecial);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_UndefineSpaceSpecial);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(platform, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(platform, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_UndefineSpaceSpecial(
@@ -68,11 +69,12 @@ TSS2_RC Tss2_Sys_NV_UndefineSpaceSpecial(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_UndefineSpaceSpecial_Prepare(sysContext, nvIndex, platform);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_Write.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Write.c
@@ -32,56 +32,57 @@ TSS2_RC Tss2_Sys_NV_Write_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    const TPM2B_MAX_NV_BUFFER	*data,
+    const TPM2B_MAX_NV_BUFFER *data,
     UINT16 offset)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_Write);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_Write);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!data) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
-        rval = Tss2_MU_TPM2B_MAX_NV_BUFFER_Marshal(data, SYS_CONTEXT->cmdBuffer,
-                                                   SYS_CONTEXT->maxCmdSize,
-                                                   &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_MAX_NV_BUFFER_Marshal(data, ctx->cmdBuffer,
+                                                   ctx->maxCmdSize,
+                                                   &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(offset, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_Write(
@@ -89,15 +90,16 @@ TSS2_RC Tss2_Sys_NV_Write(
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_MAX_NV_BUFFER	*data,
+    const TPM2B_MAX_NV_BUFFER *data,
     UINT16 offset,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_Write_Prepare(sysContext, authHandle, nvIndex, data, offset);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_WriteLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_WriteLock.c
@@ -33,32 +33,33 @@ TSS2_RC Tss2_Sys_NV_WriteLock_Prepare(
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_NV_WriteLock);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_NV_WriteLock);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_NV_WriteLock(
@@ -68,11 +69,12 @@ TSS2_RC Tss2_Sys_NV_WriteLock(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_NV_WriteLock_Prepare(sysContext, authHandle, nvIndex);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_ObjectChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_ObjectChangeAuth.c
@@ -32,58 +32,60 @@ TSS2_RC Tss2_Sys_ObjectChangeAuth_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT objectHandle,
     TPMI_DH_OBJECT parentHandle,
-    const TPM2B_AUTH	*newAuth)
+    const TPM2B_AUTH *newAuth)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ObjectChangeAuth);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ObjectChangeAuth);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(parentHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(parentHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_AUTH_Marshal(newAuth, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ObjectChangeAuth_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_PRIVATE *outPrivate)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_PRIVATE_Unmarshal(ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData,
                                            outPrivate);
 }
 
@@ -92,17 +94,18 @@ TSS2_RC Tss2_Sys_ObjectChangeAuth(
     TPMI_DH_OBJECT objectHandle,
     TPMI_DH_OBJECT parentHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_AUTH	*newAuth,
+    const TPM2B_AUTH *newAuth,
     TPM2B_PRIVATE *outPrivate,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ObjectChangeAuth_Prepare(sysContext, objectHandle, parentHandle, newAuth);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_Allocate.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Allocate.c
@@ -31,35 +31,36 @@
 TSS2_RC Tss2_Sys_PCR_Allocate_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
-    const TPML_PCR_SELECTION	*pcrAllocation)
+    const TPML_PCR_SELECTION *pcrAllocation)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !pcrAllocation)
+    if (!ctx || !pcrAllocation)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PCR_Allocate);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PCR_Allocate);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(pcrAllocation,
-                                              SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData);
+                                              ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PCR_Allocate_Complete(
@@ -69,39 +70,40 @@ TSS2_RC Tss2_Sys_PCR_Allocate_Complete(
     UINT32 *sizeNeeded,
     UINT32 *sizeAvailable)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                   SYS_CONTEXT->maxCmdSize,
-                                   &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_UINT8_Unmarshal(ctx->cmdBuffer,
+                                   ctx->maxCmdSize,
+                                   &ctx->nextData,
                                    allocationSuccess);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData,
                                     maxPCR);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData,
                                     sizeNeeded);
     if (rval)
         return rval;
 
-    return Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData,
+    return Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData,
                                     sizeAvailable);
 }
 
@@ -109,13 +111,14 @@ TSS2_RC Tss2_Sys_PCR_Allocate(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPML_PCR_SELECTION	*pcrAllocation,
+    const TPML_PCR_SELECTION *pcrAllocation,
     TPMI_YES_NO *allocationSuccess,
     UINT32 *maxPCR,
     UINT32 *sizeNeeded,
     UINT32 *sizeAvailable,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!pcrAllocation)
@@ -125,7 +128,7 @@ TSS2_RC Tss2_Sys_PCR_Allocate(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_Event.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Event.c
@@ -31,52 +31,54 @@
 TSS2_RC Tss2_Sys_PCR_Event_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
-    const TPM2B_EVENT	*eventData)
+    const TPM2B_EVENT *eventData)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PCR_Event);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PCR_Event);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(pcrHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_EVENT_Marshal(eventData, SYS_CONTEXT->cmdBuffer,
-                                       SYS_CONTEXT->maxCmdSize,
-                                       &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_EVENT_Marshal(eventData, ctx->cmdBuffer,
+                                       ctx->maxCmdSize,
+                                       &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PCR_Event_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPML_DIGEST_VALUES *digests)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPML_DIGEST_VALUES_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                SYS_CONTEXT->maxCmdSize,
-                                                &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPML_DIGEST_VALUES_Unmarshal(ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData,
                                                 digests);
 }
 
@@ -84,17 +86,18 @@ TSS2_RC Tss2_Sys_PCR_Event(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_EVENT	*eventData,
+    const TPM2B_EVENT *eventData,
     TPML_DIGEST_VALUES *digests,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PCR_Event_Prepare(sysContext, pcrHandle, eventData);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_Extend.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Extend.c
@@ -31,43 +31,45 @@
 TSS2_RC Tss2_Sys_PCR_Extend_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
-    const TPML_DIGEST_VALUES	*digests)
+    const TPML_DIGEST_VALUES *digests)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !digests)
+    if (!ctx || !digests)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PCR_Extend);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PCR_Extend);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(pcrHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_DIGEST_VALUES_Marshal(digests, SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPML_DIGEST_VALUES_Marshal(digests, ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PCR_Extend(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPML_DIGEST_VALUES	*digests,
+    const TPML_DIGEST_VALUES *digests,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!digests)
@@ -77,5 +79,5 @@ TSS2_RC Tss2_Sys_PCR_Extend(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PCR_Read.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Read.c
@@ -30,29 +30,30 @@
 
 TSS2_RC Tss2_Sys_PCR_Read_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
-    const TPML_PCR_SELECTION	*pcrSelectionIn)
+    const TPML_PCR_SELECTION *pcrSelectionIn)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !pcrSelectionIn)
+    if (!ctx || !pcrSelectionIn)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PCR_Read);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PCR_Read);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(pcrSelectionIn,
-                                              SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData);
+                                              ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PCR_Read_Complete(
@@ -61,43 +62,45 @@ TSS2_RC Tss2_Sys_PCR_Read_Complete(
     TPML_PCR_SELECTION *pcrSelectionOut,
     TPML_DIGEST *pcrValues)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                    SYS_CONTEXT->maxCmdSize,
-                                    &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
+                                    ctx->maxCmdSize,
+                                    &ctx->nextData,
                                     pcrUpdateCounter);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_PCR_SELECTION_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                SYS_CONTEXT->maxCmdSize,
-                                                &SYS_CONTEXT->nextData,
+    rval = Tss2_MU_TPML_PCR_SELECTION_Unmarshal(ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData,
                                                 pcrSelectionOut);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPML_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                         SYS_CONTEXT->maxCmdSize,
-                                         &SYS_CONTEXT->nextData, pcrValues);
+    return Tss2_MU_TPML_DIGEST_Unmarshal(ctx->cmdBuffer,
+                                         ctx->maxCmdSize,
+                                         &ctx->nextData, pcrValues);
 }
 
 TSS2_RC Tss2_Sys_PCR_Read(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPML_PCR_SELECTION	*pcrSelectionIn,
+    const TPML_PCR_SELECTION *pcrSelectionIn,
     UINT32 *pcrUpdateCounter,
     TPML_PCR_SELECTION *pcrSelectionOut,
     TPML_DIGEST *pcrValues,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!pcrSelectionIn)
@@ -107,7 +110,7 @@ TSS2_RC Tss2_Sys_PCR_Read(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_Reset.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Reset.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_PCR_Reset_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PCR_Reset);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PCR_Reset);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(pcrHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PCR_Reset(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_PCR_Reset(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PCR_Reset_Prepare(sysContext, pcrHandle);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PCR_SetAuthPolicy.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_SetAuthPolicy.c
@@ -31,74 +31,76 @@
 TSS2_RC Tss2_Sys_PCR_SetAuthPolicy_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
-    const TPM2B_DIGEST	*authPolicy,
+    const TPM2B_DIGEST *authPolicy,
     TPMI_ALG_HASH hashAlg,
     TPMI_DH_PCR pcrNum)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PCR_SetAuthPolicy);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PCR_SetAuthPolicy);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!authPolicy) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(authPolicy, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(authPolicy, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrNum, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(pcrNum, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PCR_SetAuthPolicy(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DIGEST	*authPolicy,
+    const TPM2B_DIGEST *authPolicy,
     TPMI_ALG_HASH hashAlg,
     TPMI_DH_PCR pcrNum,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PCR_SetAuthPolicy_Prepare(sysContext, authHandle, authPolicy, hashAlg, pcrNum);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PCR_SetAuthValue.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_SetAuthValue.c
@@ -31,48 +31,50 @@
 TSS2_RC Tss2_Sys_PCR_SetAuthValue_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
-    const TPM2B_DIGEST	*auth)
+    const TPM2B_DIGEST *auth)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PCR_SetAuthValue);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PCR_SetAuthValue);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(pcrHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(pcrHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_DIGEST_Marshal(auth, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PCR_SetAuthValue(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DIGEST	*auth,
+    const TPM2B_DIGEST *auth,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PCR_SetAuthValue_Prepare(sysContext, pcrHandle, auth);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PP_Commands.c
+++ b/sysapi/sysapi/Tss2_Sys_PP_Commands.c
@@ -31,51 +31,53 @@
 TSS2_RC Tss2_Sys_PP_Commands_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM auth,
-    const TPML_CC	*setList,
-    const TPML_CC	*clearList)
+    const TPML_CC *setList,
+    const TPML_CC *clearList)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !setList || !clearList)
+    if (!ctx || !setList || !clearList)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PP_Commands);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PP_Commands);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(auth, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_CC_Marshal(setList, SYS_CONTEXT->cmdBuffer,
-                                   SYS_CONTEXT->maxCmdSize,
-                                   &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPML_CC_Marshal(setList, ctx->cmdBuffer,
+                                   ctx->maxCmdSize,
+                                   &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_CC_Marshal(clearList, SYS_CONTEXT->cmdBuffer,
-                                   SYS_CONTEXT->maxCmdSize,
-                                   &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPML_CC_Marshal(clearList, ctx->cmdBuffer,
+                                   ctx->maxCmdSize,
+                                   &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PP_Commands(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM auth,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPML_CC	*setList,
-    const TPML_CC	*clearList,
+    const TPML_CC *setList,
+    const TPML_CC *clearList,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!setList || !clearList)
@@ -85,5 +87,5 @@ TSS2_RC Tss2_Sys_PP_Commands(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyAuthValue.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyAuthValue.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_PolicyAuthValue_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyAuthValue);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyAuthValue);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyAuthValue(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_PolicyAuthValue(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyAuthValue_Prepare(sysContext, policySession);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyAuthorize.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyAuthorize.c
@@ -31,77 +31,79 @@
 TSS2_RC Tss2_Sys_PolicyAuthorize_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    const TPM2B_DIGEST	*approvedPolicy,
-    const TPM2B_NONCE	*policyRef,
-    const TPM2B_NAME	*keySign,
-    const TPMT_TK_VERIFIED	*checkTicket)
+    const TPM2B_DIGEST *approvedPolicy,
+    const TPM2B_NONCE *policyRef,
+    const TPM2B_NAME *keySign,
+    const TPMT_TK_VERIFIED *checkTicket)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !checkTicket)
+    if (!ctx || !checkTicket)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyAuthorize);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyAuthorize);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!approvedPolicy) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(approvedPolicy, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(approvedPolicy, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->cmdBuffer,
-                                       SYS_CONTEXT->maxCmdSize,
-                                       &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, ctx->cmdBuffer,
+                                       ctx->maxCmdSize,
+                                       &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(keySign, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_NAME_Marshal(keySign, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_TK_VERIFIED_Marshal(checkTicket, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_TK_VERIFIED_Marshal(checkTicket, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyAuthorize(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DIGEST	*approvedPolicy,
-    const TPM2B_NONCE	*policyRef,
-    const TPM2B_NAME	*keySign,
-    const TPMT_TK_VERIFIED	*checkTicket,
+    const TPM2B_DIGEST *approvedPolicy,
+    const TPM2B_NONCE *policyRef,
+    const TPM2B_NAME *keySign,
+    const TPMT_TK_VERIFIED *checkTicket,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!checkTicket)
@@ -113,5 +115,5 @@ TSS2_RC Tss2_Sys_PolicyAuthorize(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyCommandCode.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCommandCode.c
@@ -33,32 +33,33 @@ TSS2_RC Tss2_Sys_PolicyCommandCode_Prepare(
     TPMI_SH_POLICY policySession,
     TPM2_CC code)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyCommandCode);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyCommandCode);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(code, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(code, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyCommandCode(
@@ -68,11 +69,12 @@ TSS2_RC Tss2_Sys_PolicyCommandCode(
     TPM2_CC code,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyCommandCode_Prepare(sysContext, policySession, code);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyCounterTimer.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCounterTimer.c
@@ -31,69 +31,71 @@
 TSS2_RC Tss2_Sys_PolicyCounterTimer_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    const TPM2B_OPERAND	*operandB,
+    const TPM2B_OPERAND *operandB,
     UINT16 offset,
     TPM2_EO operation)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyCounterTimer);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyCounterTimer);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!operandB) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_OPERAND_Marshal(operandB, SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_OPERAND_Marshal(operandB, ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(offset, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(operation, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(operation, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyCounterTimer(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_OPERAND	*operandB,
+    const TPM2B_OPERAND *operandB,
     UINT16 offset,
     TPM2_EO operation,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyCounterTimer_Prepare(sysContext, policySession,
@@ -101,5 +103,5 @@ TSS2_RC Tss2_Sys_PolicyCounterTimer(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyCpHash.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCpHash.c
@@ -31,48 +31,50 @@
 TSS2_RC Tss2_Sys_PolicyCpHash_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    const TPM2B_DIGEST	*cpHashA)
+    const TPM2B_DIGEST *cpHashA)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyCpHash);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyCpHash);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyCpHash(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DIGEST	*cpHashA,
+    const TPM2B_DIGEST *cpHashA,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyCpHash_Prepare(sysContext, policySession, cpHashA);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyDuplicationSelect.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyDuplicationSelect.c
@@ -31,69 +31,71 @@
 TSS2_RC Tss2_Sys_PolicyDuplicationSelect_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    const TPM2B_NAME	*objectName,
-    const TPM2B_NAME	*newParentName,
+    const TPM2B_NAME *objectName,
+    const TPM2B_NAME *newParentName,
     TPMI_YES_NO includeObject)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyDuplicationSelect);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyDuplicationSelect);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!objectName) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_NAME_Marshal(objectName, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_NAME_Marshal(objectName, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(newParentName, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_NAME_Marshal(newParentName, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(includeObject, SYS_CONTEXT->cmdBuffer,
-                                 SYS_CONTEXT->maxCmdSize,
-                                 &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT8_Marshal(includeObject, ctx->cmdBuffer,
+                                 ctx->maxCmdSize,
+                                 &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyDuplicationSelect(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_NAME	*objectName,
-    const TPM2B_NAME	*newParentName,
+    const TPM2B_NAME *objectName,
+    const TPM2B_NAME *newParentName,
     TPMI_YES_NO includeObject,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyDuplicationSelect_Prepare(sysContext, policySession,
@@ -102,5 +104,5 @@ TSS2_RC Tss2_Sys_PolicyDuplicationSelect(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyGetDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyGetDigest.c
@@ -32,44 +32,46 @@ TSS2_RC Tss2_Sys_PolicyGetDigest_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyGetDigest);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyGetDigest);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyGetDigest_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_DIGEST *policyDigest)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_DIGEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData,
                                           policyDigest);
 }
 
@@ -80,13 +82,14 @@ TSS2_RC Tss2_Sys_PolicyGetDigest(
     TPM2B_DIGEST *policyDigest,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyGetDigest_Prepare(sysContext, policySession);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyLocality.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyLocality.c
@@ -33,32 +33,33 @@ TSS2_RC Tss2_Sys_PolicyLocality_Prepare(
     TPMI_SH_POLICY policySession,
     TPMA_LOCALITY locality)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyLocality);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyLocality);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMA_LOCALITY_Marshal(locality, SYS_CONTEXT->cmdBuffer,
-                                         SYS_CONTEXT->maxCmdSize,
-                                         &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMA_LOCALITY_Marshal(locality, ctx->cmdBuffer,
+                                         ctx->maxCmdSize,
+                                         &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyLocality(
@@ -68,11 +69,12 @@ TSS2_RC Tss2_Sys_PolicyLocality(
     TPMA_LOCALITY locality,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyLocality_Prepare(sysContext, policySession, locality);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyNV.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNV.c
@@ -33,70 +33,71 @@ TSS2_RC Tss2_Sys_PolicyNV_Prepare(
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
     TPMI_SH_POLICY policySession,
-    const TPM2B_OPERAND	*operandB,
+    const TPM2B_OPERAND *operandB,
     UINT16 offset,
     TPM2_EO operation)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyNV);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyNV);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(nvIndex, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(nvIndex, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!operandB) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_OPERAND_Marshal(operandB, SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_OPERAND_Marshal(operandB, ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(offset, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(offset, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(operation, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(operation, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyNV(
@@ -105,11 +106,12 @@ TSS2_RC Tss2_Sys_PolicyNV(
     TPMI_RH_NV_INDEX nvIndex,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_OPERAND	*operandB,
+    const TPM2B_OPERAND *operandB,
     UINT16 offset,
     TPM2_EO operation,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyNV_Prepare(sysContext, authHandle, nvIndex,
@@ -118,5 +120,5 @@ TSS2_RC Tss2_Sys_PolicyNV(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyNVWritten.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNVWritten.c
@@ -33,32 +33,33 @@ TSS2_RC Tss2_Sys_PolicyNvWritten_Prepare(
     TPMI_SH_POLICY policySession,
     TPMI_YES_NO writtenSet)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyNvWritten);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyNvWritten);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(writtenSet, SYS_CONTEXT->cmdBuffer,
-                                 SYS_CONTEXT->maxCmdSize,
-                                 &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT8_Marshal(writtenSet, ctx->cmdBuffer,
+                                 ctx->maxCmdSize,
+                                 &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 
@@ -69,11 +70,12 @@ TSS2_RC Tss2_Sys_PolicyNvWritten(
     TPMI_YES_NO writtenSet,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyNvWritten_Prepare(sysContext, policySession, writtenSet);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyNameHash.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNameHash.c
@@ -31,48 +31,50 @@
 TSS2_RC Tss2_Sys_PolicyNameHash_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    const TPM2B_DIGEST	*nameHash)
+    const TPM2B_DIGEST *nameHash)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyNameHash);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyNameHash);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(nameHash, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_DIGEST_Marshal(nameHash, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyNameHash(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DIGEST	*nameHash,
+    const TPM2B_DIGEST *nameHash,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyNameHash_Prepare(sysContext, policySession, nameHash);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyOR.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyOR.c
@@ -31,43 +31,45 @@
 TSS2_RC Tss2_Sys_PolicyOR_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    const TPML_DIGEST	*pHashList)
+    const TPML_DIGEST *pHashList)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !pHashList)
+    if (!ctx || !pHashList)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyOR);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyOR);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_DIGEST_Marshal(pHashList, SYS_CONTEXT->cmdBuffer,
-                                       SYS_CONTEXT->maxCmdSize,
-                                       &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPML_DIGEST_Marshal(pHashList, ctx->cmdBuffer,
+                                       ctx->maxCmdSize,
+                                       &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyOR(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPML_DIGEST	*pHashList,
+    const TPML_DIGEST *pHashList,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!pHashList)
@@ -77,5 +79,5 @@ TSS2_RC Tss2_Sys_PolicyOR(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyPCR.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPCR.c
@@ -31,61 +31,63 @@
 TSS2_RC Tss2_Sys_PolicyPCR_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    const TPM2B_DIGEST	*pcrDigest,
-    const TPML_PCR_SELECTION	*pcrs)
+    const TPM2B_DIGEST *pcrDigest,
+    const TPML_PCR_SELECTION *pcrs)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !pcrs)
+    if (!ctx || !pcrs)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyPCR);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyPCR);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!pcrDigest) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(pcrDigest, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(pcrDigest, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(pcrs, SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(pcrs, ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyPCR(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DIGEST	*pcrDigest,
-    const TPML_PCR_SELECTION	*pcrs,
+    const TPM2B_DIGEST *pcrDigest,
+    const TPML_PCR_SELECTION *pcrs,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!pcrs)
@@ -95,5 +97,5 @@ TSS2_RC Tss2_Sys_PolicyPCR(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyPassword.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPassword.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_PolicyPassword_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyPassword);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyPassword);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyPassword(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_PolicyPassword(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyPassword_Prepare(sysContext, policySession);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyPhysicalPresence.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPhysicalPresence.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_PolicyPhysicalPresence_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyPhysicalPresence);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyPhysicalPresence);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyPhysicalPresence(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_PolicyPhysicalPresence(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyPhysicalPresence_Prepare(sysContext, policySession);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyRestart.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyRestart.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_PolicyRestart_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY sessionHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyRestart);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyRestart);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sessionHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(sessionHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyRestart(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_PolicyRestart(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicyRestart_Prepare(sysContext, sessionHandle);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicySecret.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicySecret.c
@@ -32,81 +32,82 @@ TSS2_RC Tss2_Sys_PolicySecret_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_ENTITY authHandle,
     TPMI_SH_POLICY policySession,
-    const TPM2B_NONCE	*nonceTPM,
-    const TPM2B_DIGEST	*cpHashA,
-    const TPM2B_NONCE	*policyRef,
+    const TPM2B_NONCE *nonceTPM,
+    const TPM2B_DIGEST *cpHashA,
+    const TPM2B_NONCE *policyRef,
     INT32 expiration)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicySecret);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicySecret);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!nonceTPM) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_NONCE_Marshal(nonceTPM, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_NONCE_Marshal(nonceTPM, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
     if (!cpHashA)
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     else
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     if (rval)
         return rval;
 
     if (!policyRef)
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     else
-        rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(expiration, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(expiration, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicySecret_Complete(
@@ -114,24 +115,25 @@ TSS2_RC Tss2_Sys_PolicySecret_Complete(
     TPM2B_TIMEOUT *timeout,
     TPMT_TK_AUTH *policyTicket)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_TIMEOUT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData, timeout);
+    rval = Tss2_MU_TPM2B_TIMEOUT_Unmarshal(ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData, timeout);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_AUTH_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData, policyTicket);
+    return Tss2_MU_TPMT_TK_AUTH_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData, policyTicket);
 }
 
 TSS2_RC Tss2_Sys_PolicySecret(
@@ -139,14 +141,15 @@ TSS2_RC Tss2_Sys_PolicySecret(
     TPMI_DH_ENTITY authHandle,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_NONCE	*nonceTPM,
-    const TPM2B_DIGEST	*cpHashA,
-    const TPM2B_NONCE	*policyRef,
+    const TPM2B_NONCE *nonceTPM,
+    const TPM2B_DIGEST *cpHashA,
+    const TPM2B_NONCE *policyRef,
     INT32 expiration,
     TPM2B_TIMEOUT *timeout,
     TPMT_TK_AUTH *policyTicket,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_PolicySecret_Prepare(sysContext, authHandle, policySession,
@@ -154,7 +157,7 @@ TSS2_RC Tss2_Sys_PolicySecret(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_PolicySigned.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicySigned.c
@@ -32,78 +32,79 @@ TSS2_RC Tss2_Sys_PolicySigned_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT authObject,
     TPMI_SH_POLICY policySession,
-    const TPM2B_NONCE	*nonceTPM,
-    const TPM2B_DIGEST	*cpHashA,
-    const TPM2B_NONCE	*policyRef,
+    const TPM2B_NONCE *nonceTPM,
+    const TPM2B_DIGEST *cpHashA,
+    const TPM2B_NONCE *policyRef,
     INT32 expiration,
-    const TPMT_SIGNATURE	*auth)
+    const TPMT_SIGNATURE *auth)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !auth)
+    if (!ctx || !auth)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicySigned);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicySigned);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authObject, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authObject, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!nonceTPM) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_NONCE_Marshal(nonceTPM, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_NONCE_Marshal(nonceTPM, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->cmdBuffer,
-                                       SYS_CONTEXT->maxCmdSize,
-                                       &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, ctx->cmdBuffer,
+                                       ctx->maxCmdSize,
+                                       &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(expiration, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(expiration, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIGNATURE_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_SIGNATURE_Marshal(auth, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicySigned_Complete(
@@ -111,24 +112,25 @@ TSS2_RC Tss2_Sys_PolicySigned_Complete(
     TPM2B_TIMEOUT *timeout,
     TPMT_TK_AUTH *policyTicket)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_TIMEOUT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData, timeout);
+    rval = Tss2_MU_TPM2B_TIMEOUT_Unmarshal(ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData, timeout);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_AUTH_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData, policyTicket);
+    return Tss2_MU_TPMT_TK_AUTH_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData, policyTicket);
 }
 
 TSS2_RC Tss2_Sys_PolicySigned(
@@ -136,15 +138,16 @@ TSS2_RC Tss2_Sys_PolicySigned(
     TPMI_DH_OBJECT authObject,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_NONCE	*nonceTPM,
-    const TPM2B_DIGEST	*cpHashA,
-    const TPM2B_NONCE	*policyRef,
+    const TPM2B_NONCE *nonceTPM,
+    const TPM2B_DIGEST *cpHashA,
+    const TPM2B_NONCE *policyRef,
     INT32 expiration,
-    const TPMT_SIGNATURE	*auth,
+    const TPMT_SIGNATURE *auth,
     TPM2B_TIMEOUT *timeout,
     TPMT_TK_AUTH *policyTicket,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!auth)
@@ -154,7 +157,7 @@ TSS2_RC Tss2_Sys_PolicySigned(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyTicket.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyTicket.c
@@ -31,85 +31,87 @@
 TSS2_RC Tss2_Sys_PolicyTicket_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    const TPM2B_TIMEOUT	*timeout,
-    const TPM2B_DIGEST	*cpHashA,
-    const TPM2B_NONCE	*policyRef,
-    const TPM2B_NAME	*authName,
-    const TPMT_TK_AUTH	*ticket)
+    const TPM2B_TIMEOUT *timeout,
+    const TPM2B_DIGEST *cpHashA,
+    const TPM2B_NONCE *policyRef,
+    const TPM2B_NAME *authName,
+    const TPMT_TK_AUTH *ticket)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !ticket)
+    if (!ctx || !ticket)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_PolicyTicket);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_PolicyTicket);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(policySession, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(policySession, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!timeout) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_TIMEOUT_Marshal(timeout, SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_TIMEOUT_Marshal(timeout, ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_DIGEST_Marshal(cpHashA, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, SYS_CONTEXT->cmdBuffer,
-                                       SYS_CONTEXT->maxCmdSize,
-                                       &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_NONCE_Marshal(policyRef, ctx->cmdBuffer,
+                                       ctx->maxCmdSize,
+                                       &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(authName, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_NAME_Marshal(authName, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_TK_AUTH_Marshal(ticket, SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_TK_AUTH_Marshal(ticket, ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_PolicyTicket(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_TIMEOUT	*timeout,
-    const TPM2B_DIGEST	*cpHashA,
-    const TPM2B_NONCE	*policyRef,
-    const TPM2B_NAME	*authName,
-    const TPMT_TK_AUTH	*ticket,
+    const TPM2B_TIMEOUT *timeout,
+    const TPM2B_DIGEST *cpHashA,
+    const TPM2B_NONCE *policyRef,
+    const TPM2B_NAME *authName,
+    const TPMT_TK_AUTH *ticket,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!ticket)
@@ -120,5 +122,5 @@ TSS2_RC Tss2_Sys_PolicyTicket(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_Quote.c
+++ b/sysapi/sysapi/Tss2_Sys_Quote.c
@@ -31,58 +31,59 @@
 TSS2_RC Tss2_Sys_Quote_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT signHandle,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme,
-    const TPML_PCR_SELECTION	*PCRselect)
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme,
+    const TPML_PCR_SELECTION *PCRselect)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !inScheme || !PCRselect)
+    if (!ctx || !inScheme || !PCRselect)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Quote);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Quote);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(signHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(signHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!qualifyingData) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DATA_Marshal(qualifyingData, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(PCRselect, SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPML_PCR_SELECTION_Marshal(PCRselect, ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Quote_Complete(
@@ -90,37 +91,39 @@ TSS2_RC Tss2_Sys_Quote_Complete(
     TPM2B_ATTEST *quoted,
     TPMT_SIGNATURE *signature)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData, quoted);
+    rval = Tss2_MU_TPM2B_ATTEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData, quoted);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData, signature);
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData, signature);
 }
 
 TSS2_RC Tss2_Sys_Quote(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT signHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DATA	*qualifyingData,
-    const TPMT_SIG_SCHEME	*inScheme,
-    const TPML_PCR_SELECTION	*PCRselect,
+    const TPM2B_DATA *qualifyingData,
+    const TPMT_SIG_SCHEME *inScheme,
+    const TPML_PCR_SELECTION *PCRselect,
     TPM2B_ATTEST *quoted,
     TPMT_SIGNATURE *signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!inScheme || !PCRselect)
@@ -131,7 +134,7 @@ TSS2_RC Tss2_Sys_Quote(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_RSA_Decrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_RSA_Decrypt.c
@@ -31,89 +31,92 @@
 TSS2_RC Tss2_Sys_RSA_Decrypt_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    const TPM2B_PUBLIC_KEY_RSA	*cipherText,
-    const TPMT_RSA_DECRYPT	*inScheme,
-    const TPM2B_DATA	*label)
+    const TPM2B_PUBLIC_KEY_RSA *cipherText,
+    const TPMT_RSA_DECRYPT *inScheme,
+    const TPM2B_DATA *label)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !inScheme)
+    if (!ctx || !inScheme)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_RSA_Decrypt);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_RSA_Decrypt);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!cipherText) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
         rval = Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Marshal(cipherText,
-                                                    SYS_CONTEXT->cmdBuffer,
-                                                    SYS_CONTEXT->maxCmdSize,
-                                                    &SYS_CONTEXT->nextData);
+                                                    ctx->cmdBuffer,
+                                                    ctx->maxCmdSize,
+                                                    &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_RSA_DECRYPT_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_RSA_DECRYPT_Marshal(inScheme, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(label, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_DATA_Marshal(label, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_RSA_Decrypt_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_PUBLIC_KEY_RSA *message)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                  SYS_CONTEXT->maxCmdSize,
-                                                  &SYS_CONTEXT->nextData, message);
+    return Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Unmarshal(ctx->cmdBuffer,
+                                                  ctx->maxCmdSize,
+                                                  &ctx->nextData, message);
 }
 
 TSS2_RC Tss2_Sys_RSA_Decrypt(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_PUBLIC_KEY_RSA	*cipherText,
-    const TPMT_RSA_DECRYPT	*inScheme,
-    const TPM2B_DATA	*label,
+    const TPM2B_PUBLIC_KEY_RSA *cipherText,
+    const TPMT_RSA_DECRYPT *inScheme,
+    const TPM2B_DATA *label,
     TPM2B_PUBLIC_KEY_RSA *message,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!inScheme)
@@ -124,7 +127,7 @@ TSS2_RC Tss2_Sys_RSA_Decrypt(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_RSA_Encrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_RSA_Encrypt.c
@@ -31,88 +31,91 @@
 TSS2_RC Tss2_Sys_RSA_Encrypt_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    const TPM2B_PUBLIC_KEY_RSA	*message,
-    const TPMT_RSA_DECRYPT	*inScheme,
-    const TPM2B_DATA	*label)
+    const TPM2B_PUBLIC_KEY_RSA *message,
+    const TPMT_RSA_DECRYPT *inScheme,
+    const TPM2B_DATA *label)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !inScheme)
+    if (!ctx || !inScheme)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_RSA_Encrypt);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_RSA_Encrypt);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!message) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Marshal(message, SYS_CONTEXT->cmdBuffer,
-                                                    SYS_CONTEXT->maxCmdSize,
-                                                    &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Marshal(message, ctx->cmdBuffer,
+                                                    ctx->maxCmdSize,
+                                                    &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_RSA_DECRYPT_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_RSA_DECRYPT_Marshal(inScheme, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(label, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_DATA_Marshal(label, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_RSA_Encrypt_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_PUBLIC_KEY_RSA *outData)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                  SYS_CONTEXT->maxCmdSize,
-                                                  &SYS_CONTEXT->nextData, outData);
+    return Tss2_MU_TPM2B_PUBLIC_KEY_RSA_Unmarshal(ctx->cmdBuffer,
+                                                  ctx->maxCmdSize,
+                                                  &ctx->nextData, outData);
 }
 
 TSS2_RC Tss2_Sys_RSA_Encrypt(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_PUBLIC_KEY_RSA	*message,
-    const TPMT_RSA_DECRYPT	*inScheme,
-    const TPM2B_DATA	*label,
+    const TPM2B_PUBLIC_KEY_RSA *message,
+    const TPMT_RSA_DECRYPT *inScheme,
+    const TPM2B_DATA *label,
     TPM2B_PUBLIC_KEY_RSA *outData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!inScheme)
@@ -122,7 +125,7 @@ TSS2_RC Tss2_Sys_RSA_Encrypt(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_ReadClock.c
+++ b/sysapi/sysapi/Tss2_Sys_ReadClock.c
@@ -31,38 +31,40 @@
 TSS2_RC Tss2_Sys_ReadClock_Prepare(
     TSS2_SYS_CONTEXT *sysContext)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ReadClock);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ReadClock);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 0;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 0;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ReadClock_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMS_TIME_INFO *currentTime)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMS_TIME_INFO_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPMS_TIME_INFO_Unmarshal(ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData,
                                             currentTime);
 }
 
@@ -70,13 +72,14 @@ TSS2_RC Tss2_Sys_ReadClock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMS_TIME_INFO *currentTime)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ReadClock_Prepare(sysContext);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, 0, 0);
+    rval = CommonOneCall(ctx, 0, 0);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_ReadPublic.c
+++ b/sysapi/sysapi/Tss2_Sys_ReadPublic.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_ReadPublic_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT objectHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ReadPublic);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ReadPublic);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(objectHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(objectHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ReadPublic_Complete(
@@ -60,30 +61,31 @@ TSS2_RC Tss2_Sys_ReadPublic_Complete(
     TPM2B_NAME *name,
     TPM2B_NAME *qualifiedName)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData, outPublic);
+    rval = Tss2_MU_TPM2B_PUBLIC_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData, outPublic);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData, name);
+    rval = Tss2_MU_TPM2B_NAME_Unmarshal(ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData, name);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_NAME_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData, qualifiedName);
+    return Tss2_MU_TPM2B_NAME_Unmarshal(ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData, qualifiedName);
 }
 
 TSS2_RC Tss2_Sys_ReadPublic(
@@ -95,13 +97,14 @@ TSS2_RC Tss2_Sys_ReadPublic(
     TPM2B_NAME *qualifiedName,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ReadPublic_Prepare(sysContext, objectHandle);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_Rewrap.c
+++ b/sysapi/sysapi/Tss2_Sys_Rewrap.c
@@ -32,65 +32,66 @@ TSS2_RC Tss2_Sys_Rewrap_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT oldParent,
     TPMI_DH_OBJECT newParent,
-    const TPM2B_PRIVATE	*inDuplicate,
-    const TPM2B_NAME	*name,
-    const TPM2B_ENCRYPTED_SECRET	*inSymSeed)
+    const TPM2B_PRIVATE *inDuplicate,
+    const TPM2B_NAME *name,
+    const TPM2B_ENCRYPTED_SECRET *inSymSeed)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Rewrap);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Rewrap);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(oldParent, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(oldParent, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(newParent, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(newParent, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!inDuplicate) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_PRIVATE_Marshal(inDuplicate, SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_PRIVATE_Marshal(inDuplicate, ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_NAME_Marshal(name, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_NAME_Marshal(name, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
     rval = Tss2_MU_TPM2B_ENCRYPTED_SECRET_Marshal(inSymSeed,
-                                                  SYS_CONTEXT->cmdBuffer,
-                                                  SYS_CONTEXT->maxCmdSize,
-                                                  &SYS_CONTEXT->nextData);
+                                                  ctx->cmdBuffer,
+                                                  ctx->maxCmdSize,
+                                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Rewrap_Complete(
@@ -98,24 +99,25 @@ TSS2_RC Tss2_Sys_Rewrap_Complete(
     TPM2B_PRIVATE *outDuplicate,
     TPM2B_ENCRYPTED_SECRET *outSymSeed)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData, outDuplicate);
+    rval = Tss2_MU_TPM2B_PRIVATE_Unmarshal(ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData, outDuplicate);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                    SYS_CONTEXT->maxCmdSize,
-                                                    &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_ENCRYPTED_SECRET_Unmarshal(ctx->cmdBuffer,
+                                                    ctx->maxCmdSize,
+                                                    &ctx->nextData,
                                                     outSymSeed);
 }
 
@@ -124,20 +126,21 @@ TSS2_RC Tss2_Sys_Rewrap(
     TPMI_DH_OBJECT oldParent,
     TPMI_DH_OBJECT newParent,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_PRIVATE	*inDuplicate,
-    const TPM2B_NAME	*name,
-    const TPM2B_ENCRYPTED_SECRET	*inSymSeed,
+    const TPM2B_PRIVATE *inDuplicate,
+    const TPM2B_NAME *name,
+    const TPM2B_ENCRYPTED_SECRET *inSymSeed,
     TPM2B_PRIVATE *outDuplicate,
     TPM2B_ENCRYPTED_SECRET *outSymSeed,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_Rewrap_Prepare(sysContext, oldParent, newParent, inDuplicate, name, inSymSeed);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_SelfTest.c
+++ b/sysapi/sysapi/Tss2_Sys_SelfTest.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_SelfTest_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_YES_NO fullTest)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_SelfTest);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_SelfTest);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT8_Marshal(fullTest, SYS_CONTEXT->cmdBuffer,
-                                 SYS_CONTEXT->maxCmdSize,
-                                 &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT8_Marshal(fullTest, ctx->cmdBuffer,
+                                 ctx->maxCmdSize,
+                                 &ctx->nextData);
      if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_SelfTest(
@@ -60,12 +61,13 @@ TSS2_RC Tss2_Sys_SelfTest(
     TPMI_YES_NO fullTest,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_SelfTest_Prepare(sysContext, fullTest);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray,
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray,
                                           rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_SequenceComplete.c
+++ b/sysapi/sysapi/Tss2_Sys_SequenceComplete.c
@@ -31,51 +31,52 @@
 TSS2_RC Tss2_Sys_SequenceComplete_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT sequenceHandle,
-    const TPM2B_MAX_BUFFER	*buffer,
+    const TPM2B_MAX_BUFFER *buffer,
     TPMI_RH_HIERARCHY hierarchy)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_SequenceComplete);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_SequenceComplete);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!buffer) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->cmdBuffer,
-                                                SYS_CONTEXT->maxCmdSize,
-                                                &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(hierarchy, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(hierarchy, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_SequenceComplete_Complete(
@@ -83,36 +84,38 @@ TSS2_RC Tss2_Sys_SequenceComplete_Complete(
     TPM2B_DIGEST *result,
     TPMT_TK_HASHCHECK *validation)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData, result);
+    rval = Tss2_MU_TPM2B_DIGEST_Unmarshal(ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData, result);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_HASHCHECK_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                               SYS_CONTEXT->maxCmdSize,
-                                               &SYS_CONTEXT->nextData, validation);
+    return Tss2_MU_TPMT_TK_HASHCHECK_Unmarshal(ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData, validation);
 }
 
 TSS2_RC Tss2_Sys_SequenceComplete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT sequenceHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_MAX_BUFFER	*buffer,
+    const TPM2B_MAX_BUFFER *buffer,
     TPMI_RH_HIERARCHY hierarchy,
     TPM2B_DIGEST *result,
     TPMT_TK_HASHCHECK *validation,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_SequenceComplete_Prepare(sysContext, sequenceHandle,
@@ -120,7 +123,7 @@ TSS2_RC Tss2_Sys_SequenceComplete(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_SequenceUpdate.c
+++ b/sysapi/sysapi/Tss2_Sys_SequenceUpdate.c
@@ -31,48 +31,50 @@
 TSS2_RC Tss2_Sys_SequenceUpdate_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT sequenceHandle,
-    const TPM2B_MAX_BUFFER	*buffer)
+    const TPM2B_MAX_BUFFER *buffer)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_SequenceUpdate);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_SequenceUpdate);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(sequenceHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_MAX_BUFFER_Marshal(buffer, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_SequenceUpdate(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT sequenceHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_MAX_BUFFER	*buffer,
+    const TPM2B_MAX_BUFFER *buffer,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_SequenceUpdate_Prepare(sysContext, sequenceHandle, buffer);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_SetAlgorithmSet.c
+++ b/sysapi/sysapi/Tss2_Sys_SetAlgorithmSet.c
@@ -33,32 +33,33 @@ TSS2_RC Tss2_Sys_SetAlgorithmSet_Prepare(
     TPMI_RH_PLATFORM authHandle,
     UINT32 algorithmSet)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_SetAlgorithmSet);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_SetAlgorithmSet);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(algorithmSet, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(algorithmSet, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_SetAlgorithmSet(
@@ -68,11 +69,12 @@ TSS2_RC Tss2_Sys_SetAlgorithmSet(
     UINT32 algorithmSet,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_SetAlgorithmSet_Prepare(sysContext, authHandle, algorithmSet);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_SetCommandCodeAuditStatus.c
+++ b/sysapi/sysapi/Tss2_Sys_SetCommandCodeAuditStatus.c
@@ -32,47 +32,48 @@ TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION auth,
     TPMI_ALG_HASH auditAlg,
-    const TPML_CC	*setList,
-    const TPML_CC	*clearList)
+    const TPML_CC *setList,
+    const TPML_CC *clearList)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !setList  || !clearList)
+    if (!ctx || !setList  || !clearList)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_SetCommandCodeAuditStatus);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_SetCommandCodeAuditStatus);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(auth, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(auth, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(auditAlg, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(auditAlg, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_CC_Marshal(setList, SYS_CONTEXT->cmdBuffer,
-                                   SYS_CONTEXT->maxCmdSize,
-                                   &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPML_CC_Marshal(setList, ctx->cmdBuffer,
+                                   ctx->maxCmdSize,
+                                   &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPML_CC_Marshal(clearList, SYS_CONTEXT->cmdBuffer,
-                                   SYS_CONTEXT->maxCmdSize,
-                                   &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPML_CC_Marshal(clearList, ctx->cmdBuffer,
+                                   ctx->maxCmdSize,
+                                   &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus(
@@ -80,10 +81,11 @@ TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus(
     TPMI_RH_PROVISION auth,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPMI_ALG_HASH auditAlg,
-    const TPML_CC	*setList,
-    const TPML_CC	*clearList,
+    const TPML_CC *setList,
+    const TPML_CC *clearList,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!setList || !clearList)
@@ -94,5 +96,5 @@ TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_SetPrimaryPolicy.c
+++ b/sysapi/sysapi/Tss2_Sys_SetPrimaryPolicy.c
@@ -31,66 +31,68 @@
 TSS2_RC Tss2_Sys_SetPrimaryPolicy_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY_AUTH authHandle,
-    const TPM2B_DIGEST	*authPolicy,
+    const TPM2B_DIGEST *authPolicy,
     TPMI_ALG_HASH hashAlg)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_SetPrimaryPolicy);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_SetPrimaryPolicy);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(authHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(authHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!authPolicy) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(authPolicy, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(authPolicy, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(hashAlg, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(hashAlg, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_SetPrimaryPolicy(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY_AUTH authHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DIGEST	*authPolicy,
+    const TPM2B_DIGEST *authPolicy,
     TPMI_ALG_HASH hashAlg,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_SetPrimaryPolicy_Prepare(sysContext, authHandle, authPolicy, hashAlg);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_Shutdown.c
+++ b/sysapi/sysapi/Tss2_Sys_Shutdown.c
@@ -32,26 +32,27 @@ TSS2_RC Tss2_Sys_Shutdown_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2_SU shutdownType)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Shutdown);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Shutdown);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(shutdownType, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(shutdownType, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Shutdown(
@@ -60,11 +61,12 @@ TSS2_RC Tss2_Sys_Shutdown(
     TPM2_SU shutdownType,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_Shutdown_Prepare(sysContext, shutdownType);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_Sign.c
+++ b/sysapi/sysapi/Tss2_Sys_Sign.c
@@ -31,88 +31,91 @@
 TSS2_RC Tss2_Sys_Sign_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    const TPM2B_DIGEST	*digest,
-    const TPMT_SIG_SCHEME	*inScheme,
-    const TPMT_TK_HASHCHECK	*validation)
+    const TPM2B_DIGEST *digest,
+    const TPMT_SIG_SCHEME *inScheme,
+    const TPMT_TK_HASHCHECK *validation)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !inScheme || !validation)
+    if (!ctx || !inScheme || !validation)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Sign);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Sign);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!digest) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(digest, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(digest, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_SIG_SCHEME_Marshal(inScheme, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_TK_HASHCHECK_Marshal(validation, SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_TK_HASHCHECK_Marshal(validation, ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Sign_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMT_SIGNATURE *signature)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData, signature);
+    return Tss2_MU_TPMT_SIGNATURE_Unmarshal(ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData, signature);
 }
 
 TSS2_RC Tss2_Sys_Sign(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DIGEST	*digest,
-    const TPMT_SIG_SCHEME	*inScheme,
-    const TPMT_TK_HASHCHECK	*validation,
+    const TPM2B_DIGEST *digest,
+    const TPMT_SIG_SCHEME *inScheme,
+    const TPMT_TK_HASHCHECK *validation,
     TPMT_SIGNATURE *signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!inScheme || !validation)
@@ -122,7 +125,7 @@ TSS2_RC Tss2_Sys_Sign(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_Startup.c
+++ b/sysapi/sysapi/Tss2_Sys_Startup.c
@@ -32,37 +32,39 @@ TSS2_RC Tss2_Sys_Startup_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2_SU startupType)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Startup);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Startup);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(startupType, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(startupType, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 0;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 0;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Startup(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2_SU startupType)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_Startup_Prepare(sysContext, startupType);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, 0, 0);
+    return CommonOneCallForNoResponseCmds(ctx, 0, 0);
 }

--- a/sysapi/sysapi/Tss2_Sys_StirRandom.c
+++ b/sysapi/sysapi/Tss2_Sys_StirRandom.c
@@ -30,41 +30,43 @@
 
 TSS2_RC Tss2_Sys_StirRandom_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
-    const TPM2B_SENSITIVE_DATA	*inData)
+    const TPM2B_SENSITIVE_DATA *inData)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_StirRandom);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_StirRandom);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(inData, SYS_CONTEXT->cmdBuffer,
-                                                SYS_CONTEXT->maxCmdSize,
-                                                &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_SENSITIVE_DATA_Marshal(inData, ctx->cmdBuffer,
+                                                ctx->maxCmdSize,
+                                                &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_StirRandom(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_SENSITIVE_DATA	*inData,
+    const TPM2B_SENSITIVE_DATA *inData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_StirRandom_Prepare(sysContext, inData);
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_TestParms.c
+++ b/sysapi/sysapi/Tss2_Sys_TestParms.c
@@ -30,36 +30,38 @@
 
 TSS2_RC Tss2_Sys_TestParms_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
-    const TPMT_PUBLIC_PARMS	*parameters)
+    const TPMT_PUBLIC_PARMS *parameters)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !parameters)
+    if (!ctx || !parameters)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_TestParms);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_TestParms);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_PUBLIC_PARMS_Marshal(parameters, SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_PUBLIC_PARMS_Marshal(parameters, ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_TestParms(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPMT_PUBLIC_PARMS	*parameters,
+    const TPMT_PUBLIC_PARMS *parameters,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!parameters)
@@ -69,5 +71,5 @@ TSS2_RC Tss2_Sys_TestParms(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(sysContext, cmdAuthsArray, rspAuthsArray);
+    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
 }

--- a/sysapi/sysapi/Tss2_Sys_Unseal.c
+++ b/sysapi/sysapi/Tss2_Sys_Unseal.c
@@ -32,44 +32,46 @@ TSS2_RC Tss2_Sys_Unseal_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT itemHandle)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Unseal);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Unseal);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(itemHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(itemHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 0;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 0;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Unseal_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_SENSITIVE_DATA *outData)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_SENSITIVE_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                                  SYS_CONTEXT->maxCmdSize,
-                                                  &SYS_CONTEXT->nextData,
+    return Tss2_MU_TPM2B_SENSITIVE_DATA_Unmarshal(ctx->cmdBuffer,
+                                                  ctx->maxCmdSize,
+                                                  &ctx->nextData,
                                                   outData);
 }
 
@@ -80,13 +82,14 @@ TSS2_RC Tss2_Sys_Unseal(
     TPM2B_SENSITIVE_DATA *outData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_Unseal_Prepare(sysContext, itemHandle);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_Vendor_TCG_Test.c
+++ b/sysapi/sysapi/Tss2_Sys_Vendor_TCG_Test.c
@@ -30,62 +30,65 @@
 
 TSS2_RC Tss2_Sys_Vendor_TCG_Test_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
-    const TPM2B_DATA	*inputData)
+    const TPM2B_DATA *inputData)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_Vendor_TCG_Test);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_Vendor_TCG_Test);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_DATA_Marshal(inputData, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_DATA_Marshal(inputData, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_Vendor_TCG_Test_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2B_DATA *outputData)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_DATA_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                        SYS_CONTEXT->maxCmdSize,
-                                        &SYS_CONTEXT->nextData, outputData);
+    return Tss2_MU_TPM2B_DATA_Unmarshal(ctx->cmdBuffer,
+                                        ctx->maxCmdSize,
+                                        &ctx->nextData, outputData);
 }
 
 TSS2_RC Tss2_Sys_Vendor_TCG_Test(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DATA	*inputData,
+    const TPM2B_DATA *inputData,
     TPM2B_DATA *outputData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_Vendor_TCG_Test_Prepare(sysContext, inputData);
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_VerifySignature.c
+++ b/sysapi/sysapi/Tss2_Sys_VerifySignature.c
@@ -31,80 +31,83 @@
 TSS2_RC Tss2_Sys_VerifySignature_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    const TPM2B_DIGEST	*digest,
-    const TPMT_SIGNATURE	*signature)
+    const TPM2B_DIGEST *digest,
+    const TPMT_SIGNATURE *signature)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext || !signature)
+    if (!ctx || !signature)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_VerifySignature);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_VerifySignature);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyHandle, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(keyHandle, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!digest) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_DIGEST_Marshal(digest, SYS_CONTEXT->cmdBuffer,
-                                            SYS_CONTEXT->maxCmdSize,
-                                            &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_DIGEST_Marshal(digest, ctx->cmdBuffer,
+                                            ctx->maxCmdSize,
+                                            &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPMT_SIGNATURE_Marshal(signature, SYS_CONTEXT->cmdBuffer,
-                                          SYS_CONTEXT->maxCmdSize,
-                                          &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPMT_SIGNATURE_Marshal(signature, ctx->cmdBuffer,
+                                          ctx->maxCmdSize,
+                                          &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 0;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 0;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_VerifySignature_Complete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMT_TK_VERIFIED *validation)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPMT_TK_VERIFIED_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                              SYS_CONTEXT->maxCmdSize,
-                                              &SYS_CONTEXT->nextData, validation);
+    return Tss2_MU_TPMT_TK_VERIFIED_Unmarshal(ctx->cmdBuffer,
+                                              ctx->maxCmdSize,
+                                              &ctx->nextData, validation);
 }
 
 TSS2_RC Tss2_Sys_VerifySignature(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_DIGEST	*digest,
-    const TPMT_SIGNATURE	*signature,
+    const TPM2B_DIGEST *digest,
+    const TPMT_SIGNATURE *signature,
     TPMT_TK_VERIFIED *validation,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     if (!signature)
@@ -114,7 +117,7 @@ TSS2_RC Tss2_Sys_VerifySignature(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/sysapi/sysapi/Tss2_Sys_ZGen_2Phase.c
+++ b/sysapi/sysapi/Tss2_Sys_ZGen_2Phase.c
@@ -31,65 +31,66 @@
 TSS2_RC Tss2_Sys_ZGen_2Phase_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyA,
-    const TPM2B_ECC_POINT	*inQsB,
-    const TPM2B_ECC_POINT	*inQeB,
+    const TPM2B_ECC_POINT *inQsB,
+    const TPM2B_ECC_POINT *inQeB,
     TPMI_ECC_KEY_EXCHANGE inScheme,
     UINT16 counter)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonPreparePrologue(sysContext, TPM2_CC_ZGen_2Phase);
+    rval = CommonPreparePrologue(ctx, TPM2_CC_ZGen_2Phase);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT32_Marshal(keyA, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT32_Marshal(keyA, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
     if (!inQsB) {
-        SYS_CONTEXT->decryptNull = 1;
+        ctx->decryptNull = 1;
 
-        rval = Tss2_MU_UINT16_Marshal(0, SYS_CONTEXT->cmdBuffer,
-                                      SYS_CONTEXT->maxCmdSize,
-                                      &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_UINT16_Marshal(0, ctx->cmdBuffer,
+                                      ctx->maxCmdSize,
+                                      &ctx->nextData);
     } else {
 
-        rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inQsB, SYS_CONTEXT->cmdBuffer,
-                                               SYS_CONTEXT->maxCmdSize,
-                                               &SYS_CONTEXT->nextData);
+        rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inQsB, ctx->cmdBuffer,
+                                               ctx->maxCmdSize,
+                                               &ctx->nextData);
     }
 
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inQeB, SYS_CONTEXT->cmdBuffer,
-                                           SYS_CONTEXT->maxCmdSize,
-                                           &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_TPM2B_ECC_POINT_Marshal(inQeB, ctx->cmdBuffer,
+                                           ctx->maxCmdSize,
+                                           &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(inScheme, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(inScheme, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_UINT16_Marshal(counter, SYS_CONTEXT->cmdBuffer,
-                                  SYS_CONTEXT->maxCmdSize,
-                                  &SYS_CONTEXT->nextData);
+    rval = Tss2_MU_UINT16_Marshal(counter, ctx->cmdBuffer,
+                                  ctx->maxCmdSize,
+                                  &ctx->nextData);
     if (rval)
         return rval;
 
-    SYS_CONTEXT->decryptAllowed = 1;
-    SYS_CONTEXT->encryptAllowed = 1;
-    SYS_CONTEXT->authAllowed = 1;
+    ctx->decryptAllowed = 1;
+    ctx->encryptAllowed = 1;
+    ctx->authAllowed = 1;
 
-    return CommonPrepareEpilogue(sysContext);
+    return CommonPrepareEpilogue(ctx);
 }
 
 TSS2_RC Tss2_Sys_ZGen_2Phase_Complete(
@@ -97,38 +98,40 @@ TSS2_RC Tss2_Sys_ZGen_2Phase_Complete(
     TPM2B_ECC_POINT *outZ1,
     TPM2B_ECC_POINT *outZ2)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
-    if (!sysContext)
+    if (!ctx)
         return TSS2_SYS_RC_BAD_REFERENCE;
 
-    rval = CommonComplete(sysContext);
+    rval = CommonComplete(ctx);
     if (rval)
         return rval;
 
-    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData, outZ1);
+    rval = Tss2_MU_TPM2B_ECC_POINT_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData, outZ1);
     if (rval)
         return rval;
 
-    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(SYS_CONTEXT->cmdBuffer,
-                                             SYS_CONTEXT->maxCmdSize,
-                                             &SYS_CONTEXT->nextData, outZ2);
+    return Tss2_MU_TPM2B_ECC_POINT_Unmarshal(ctx->cmdBuffer,
+                                             ctx->maxCmdSize,
+                                             &ctx->nextData, outZ2);
 }
 
 TSS2_RC Tss2_Sys_ZGen_2Phase(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyA,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    const TPM2B_ECC_POINT	*inQsB,
-    const TPM2B_ECC_POINT	*inQeB,
+    const TPM2B_ECC_POINT *inQsB,
+    const TPM2B_ECC_POINT *inQeB,
     TPMI_ECC_KEY_EXCHANGE inScheme,
     UINT16 counter,
     TPM2B_ECC_POINT *outZ1,
     TPM2B_ECC_POINT *outZ2,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray)
 {
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;
 
     rval = Tss2_Sys_ZGen_2Phase_Prepare(sysContext, keyA, inQsB, inQeB,
@@ -136,7 +139,7 @@ TSS2_RC Tss2_Sys_ZGen_2Phase(
     if (rval)
         return rval;
 
-    rval = CommonOneCall(sysContext, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
     if (rval)
         return rval;
 

--- a/test/unit/CommonPreparePrologue.c
+++ b/test/unit/CommonPreparePrologue.c
@@ -63,7 +63,7 @@ CommonPreparePrologue_previous_stage_initialize (void **state)
     TSS2_RC rc;
 
     sys_ctx->previousStage |= ~CMD_STAGE_INITIALIZE;
-    rc = CommonPreparePrologue ((TSS2_SYS_CONTEXT*)sys_ctx, 0);
+    rc = CommonPreparePrologue (sys_ctx, 0);
     assert_int_equal (rc, TSS2_SYS_RC_BAD_SEQUENCE);
 }
 static void
@@ -73,7 +73,7 @@ CommonPreparePrologue_previous_stage_prepare (void **state)
     TSS2_RC rc;
 
     sys_ctx->previousStage |= ~CMD_STAGE_RECEIVE_RESPONSE;
-    rc = CommonPreparePrologue ((TSS2_SYS_CONTEXT*)sys_ctx, 0);
+    rc = CommonPreparePrologue (sys_ctx, 0);
     assert_int_equal (rc, TSS2_SYS_RC_BAD_SEQUENCE);
 }
 static void
@@ -83,7 +83,7 @@ CommonPreparePrologue_previous_stage_response (void **state)
     TSS2_RC rc;
 
     sys_ctx->previousStage |= ~CMD_STAGE_PREPARE;
-    rc = CommonPreparePrologue ((TSS2_SYS_CONTEXT*)sys_ctx, 0);
+    rc = CommonPreparePrologue (sys_ctx, 0);
     assert_int_equal (rc, TSS2_SYS_RC_BAD_SEQUENCE);
 }
 int

--- a/test/unit/CopyCommandHeader.c
+++ b/test/unit/CopyCommandHeader.c
@@ -27,8 +27,8 @@ CopyCommandHeader_sys_setup (void **state)
      *  must point to the data after the context structure.
      */
     sys_ctx->cmdBuffer = (UINT8*) (sys_ctx + sizeof (_TSS2_SYS_CONTEXT_BLOB));
-    InitSysContextFields ((TSS2_SYS_CONTEXT*)sys_ctx);
-    InitSysContextPtrs ((TSS2_SYS_CONTEXT*)sys_ctx, size_ctx);
+    InitSysContextFields (sys_ctx);
+    InitSysContextPtrs (sys_ctx, size_ctx);
 
     *state = sys_ctx;
     return 0;
@@ -54,11 +54,11 @@ CopyCommandHeader_sys_teardown (void **state)
 static void
 CopyCommandHeader_nextData_unit (void **state)
 {
-    TSS2_SYS_CONTEXT *sys_ctx = (TSS2_SYS_CONTEXT*)*state;
+    _TSS2_SYS_CONTEXT_BLOB *sys_ctx = (_TSS2_SYS_CONTEXT_BLOB *)*state;
     TPM2_CC cc = TPM2_CC_GetCapability;
 
     CopyCommandHeader (sys_ctx, cc);
-    assert_int_equal (((_TSS2_SYS_CONTEXT_BLOB *)sys_ctx)->nextData, sizeof (TPM20_Header_In));
+    assert_int_equal (sys_ctx->nextData, sizeof (TPM20_Header_In));
 }
 
 /**
@@ -78,7 +78,7 @@ CopyCommandHeader_tag_unit (void **state)
      */
     TPMI_ST_COMMAND_TAG tag_net = htons (TPM2_ST_NO_SESSIONS);
 
-    CopyCommandHeader ((TSS2_SYS_CONTEXT*)sys_ctx, cc);
+    CopyCommandHeader (sys_ctx, cc);
     assert_int_equal (tag_net, header->tag);
 }
 /**
@@ -94,7 +94,7 @@ CopyCommandHeader_commandcode_unit (void **state)
     TPM2_CC cc_net = htonl (cc);
     TPM20_Header_In *header = (TPM20_Header_In*)sys_ctx->cmdBuffer;
 
-    CopyCommandHeader ((TSS2_SYS_CONTEXT*)sys_ctx, cc);
+    CopyCommandHeader (sys_ctx, cc);
     assert_int_equal (cc_net, header->commandCode);
 }
 


### PR DESCRIPTION
The SYS_CONTEXT macro, which assumed that a local variable named
"sysContext" will be valid in a given block of code, is replaced
by syscontext_cast() inline function.
This should prevent errors caused by local variable eclipse etc.
The external Tss2_Sys_*() functions take the same TSS2_SYS_CONTEXT * type
and all internal helpers pass _TSS2_SYS_CONTEXT_BLOB *.
The syscontext_cast() does the conversion between the two types.