### PR TITLE
tcti: Fixed tcti function macros to use CamelCase

### DIFF
--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -85,21 +85,21 @@ typedef void TSS2_TCTI_POLL_HANDLE;
     ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->setLocality
 
 // Macros to simplify invocation of functions from the common TCTI structure
-#define tss2_tcti_transmit(tctiContext, size, command) \
+#define Tss2_Tcti_Transmit(tctiContext, size, command) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_TRANSMIT(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_TRANSMIT(tctiContext)(tctiContext, size, command))
-#define tss2_tcti_receive(tctiContext, size, response, timeout) \
+#define Tss2_Tcti_Receive(tctiContext, size, response, timeout) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_RECEIVE(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_RECEIVE(tctiContext)(tctiContext, size, response, timeout))
-#define tss2_tcti_finalize(tctiContext) \
+#define Tss2_Tcti_Finalize(tctiContext) \
     do { \
         if ((tctiContext != NULL) && \
             (TSS2_TCTI_VERSION(tctiContext) >= 1) && \
@@ -108,27 +108,37 @@ typedef void TSS2_TCTI_POLL_HANDLE;
             TSS2_TCTI_FINALIZE(tctiContext)(tctiContext); \
         } \
     } while (0)
-#define tss2_tcti_cancel(tctiContext) \
+#define Tss2_Tcti_Cancel(tctiContext) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_CANCEL(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_CANCEL(tctiContext)(tctiContext))
-#define tss2_tcti_get_poll_handles(tctiContext, handles, num_handles) \
+#define Tss2_Tcti_GetPollHandles(tctiContext, handles, num_handles) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_GET_POLL_HANDLES(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_GET_POLL_HANDLES(tctiContext)(tctiContext, handles, num_handles))
-#define tss2_tcti_set_locality(tctiContext, locality) \
+#define Tss2_Tcti_SetLocality(tctiContext, locality) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_SET_LOCALITY(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_SET_LOCALITY(tctiContext)(tctiContext, locality))
+
+/* The following defines are kept for compatibility reasons.
+ * They are however deprecated.
+ * TODO: Must be removed before release */
+#define tss2_tcti_transmit Tss2_Tcti_Transmit
+#define tss2_tcti_receive Tss2_Tcti_Receive
+#define tss2_tcti_finalize Tss2_Tcti_Finalize
+#define tss2_tcti_cancel Tss2_Tcti_Cancel
+#define tss2_tcti_get_poll_handles Tss2_Tcti_GetPollHandles
+#define tss2_tcti_set_locality Tss2_Tcti_SetLocality
 
 typedef struct TSS2_TCTI_OPAQUE_CONTEXT_BLOB TSS2_TCTI_CONTEXT;
 

--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -145,11 +145,6 @@ void InitSysContextPtrs(_TSS2_SYS_CONTEXT_BLOB *ctx, size_t contextSize);
 TSS2_RC CompleteChecks(_TSS2_SYS_CONTEXT_BLOB *ctx);
 TSS2_RC CommonComplete(_TSS2_SYS_CONTEXT_BLOB *ctx);
 
-TSS2_RC  CommonOneCallForNoResponseCmds(
-    _TSS2_SYS_CONTEXT_BLOB *ctx,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray);
-
 TSS2_RC CommonOneCall(
     _TSS2_SYS_CONTEXT_BLOB *ctx,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,

--- a/sysapi/sysapi/Tss2_Sys_ChangeEPS.c
+++ b/sysapi/sysapi/Tss2_Sys_ChangeEPS.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_ChangeEPS_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_ChangeEPS_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_ChangeEPS(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_ChangeEPS(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_ChangeEPS_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_ChangePPS.c
+++ b/sysapi/sysapi/Tss2_Sys_ChangePPS.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_ChangePPS_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_ChangePPS_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_ChangePPS(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_ChangePPS(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_ChangePPS_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_Clear.c
+++ b/sysapi/sysapi/Tss2_Sys_Clear.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_Clear_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_Clear_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_Clear(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_CLEAR authHandle,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_Clear(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_Clear_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_ClearControl.c
+++ b/sysapi/sysapi/Tss2_Sys_ClearControl.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_ClearControl_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_ClearControl_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_ClearControl(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_CLEAR auth,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_ClearControl(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_ClearControl_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_ClockRateAdjust.c
+++ b/sysapi/sysapi/Tss2_Sys_ClockRateAdjust.c
@@ -61,6 +61,17 @@ TSS2_RC Tss2_Sys_ClockRateAdjust_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_ClockRateAdjust_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_ClockRateAdjust(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION auth,
@@ -75,5 +86,9 @@ TSS2_RC Tss2_Sys_ClockRateAdjust(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_ClockRateAdjust_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_ClockSet.c
+++ b/sysapi/sysapi/Tss2_Sys_ClockSet.c
@@ -61,6 +61,17 @@ TSS2_RC Tss2_Sys_ClockSet_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_ClockSet_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_ClockSet(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION auth,
@@ -75,5 +86,9 @@ TSS2_RC Tss2_Sys_ClockSet(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_ClockSet_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_DictionaryAttackLockReset.c
+++ b/sysapi/sysapi/Tss2_Sys_DictionaryAttackLockReset.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_DictionaryAttackLockReset_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_DictionaryAttackLockReset_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_DictionaryAttackLockReset(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_LOCKOUT lockHandle,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_DictionaryAttackLockReset(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_DictionaryAttackLockReset_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_DictionaryAttackParameters.c
+++ b/sysapi/sysapi/Tss2_Sys_DictionaryAttackParameters.c
@@ -75,6 +75,17 @@ TSS2_RC Tss2_Sys_DictionaryAttackParameters_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_DictionaryAttackParameters_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_DictionaryAttackParameters(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_LOCKOUT lockHandle,
@@ -92,5 +103,9 @@ TSS2_RC Tss2_Sys_DictionaryAttackParameters(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_DictionaryAttackParameters_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_EvictControl.c
+++ b/sysapi/sysapi/Tss2_Sys_EvictControl.c
@@ -67,6 +67,17 @@ TSS2_RC Tss2_Sys_EvictControl_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_EvictControl_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_EvictControl(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION auth,
@@ -83,6 +94,9 @@ TSS2_RC Tss2_Sys_EvictControl(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray,
-                                          rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_EvictControl_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_FieldUpgradeStart.c
+++ b/sysapi/sysapi/Tss2_Sys_FieldUpgradeStart.c
@@ -86,6 +86,17 @@ TSS2_RC Tss2_Sys_FieldUpgradeStart_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_FieldUpgradeStart_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_FieldUpgradeStart(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authorization,
@@ -107,5 +118,9 @@ TSS2_RC Tss2_Sys_FieldUpgradeStart(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_FieldUpgradeStart_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_Finalize.c
+++ b/sysapi/sysapi/Tss2_Sys_Finalize.c
@@ -28,6 +28,17 @@
 #include "sapi/tpm20.h"
 #include "sysapi_util.h"
 
+TSS2_RC Tss2_Sys_Finalize_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_Finalize(
     TSS2_SYS_CONTEXT *sysContext)
 {

--- a/sysapi/sysapi/Tss2_Sys_FlushContext.c
+++ b/sysapi/sysapi/Tss2_Sys_FlushContext.c
@@ -54,6 +54,17 @@ TSS2_RC Tss2_Sys_FlushContext_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_FlushContext_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_FlushContext(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_CONTEXT flushHandle)
@@ -65,5 +76,9 @@ TSS2_RC Tss2_Sys_FlushContext(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, 0, 0);
+    rval = CommonOneCall(ctx, 0, 0);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_FlushContext_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_HierarchyChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_HierarchyChangeAuth.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_HierarchyChangeAuth_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_HierarchyChangeAuth_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_HierarchyChangeAuth(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY_AUTH authHandle,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_HierarchyChangeAuth(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_HierarchyChangeAuth_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_HierarchyControl.c
+++ b/sysapi/sysapi/Tss2_Sys_HierarchyControl.c
@@ -69,6 +69,17 @@ TSS2_RC Tss2_Sys_HierarchyControl_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_HierarchyControl_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_HierarchyControl(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY authHandle,
@@ -84,5 +95,9 @@ TSS2_RC Tss2_Sys_HierarchyControl(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_HierarchyControl_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_ChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ChangeAuth.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_NV_ChangeAuth_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_ChangeAuth_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_ChangeAuth(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX nvIndex,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_NV_ChangeAuth(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_ChangeAuth_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_DefineSpace.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_DefineSpace.c
@@ -79,6 +79,17 @@ TSS2_RC Tss2_Sys_NV_DefineSpace_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_DefineSpace_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_DefineSpace(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION authHandle,
@@ -94,5 +105,9 @@ TSS2_RC Tss2_Sys_NV_DefineSpace(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_DefineSpace_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_Extend.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Extend.c
@@ -69,6 +69,17 @@ TSS2_RC Tss2_Sys_NV_Extend_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_Extend_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_Extend(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
@@ -84,5 +95,9 @@ TSS2_RC Tss2_Sys_NV_Extend(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_Extend_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_GlobalWriteLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_GlobalWriteLock.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_NV_GlobalWriteLock_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_GlobalWriteLock_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_GlobalWriteLock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION authHandle,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_NV_GlobalWriteLock(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_GlobalWriteLock_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_Increment.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Increment.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_NV_Increment_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_Increment_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_Increment(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_NV_Increment(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_Increment_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_ReadLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ReadLock.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_NV_ReadLock_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_ReadLock_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_ReadLock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_NV_ReadLock(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_ReadLock_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_SetBits.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_SetBits.c
@@ -69,6 +69,17 @@ TSS2_RC Tss2_Sys_NV_SetBits_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_SetBits_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_SetBits(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
@@ -84,5 +95,9 @@ TSS2_RC Tss2_Sys_NV_SetBits(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_SetBits_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_UndefineSpace.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_UndefineSpace.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_NV_UndefineSpace_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_UndefineSpace_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_UndefineSpace(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION authHandle,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_NV_UndefineSpace(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_UndefineSpace_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_UndefineSpaceSpecial.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_UndefineSpaceSpecial.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_NV_UndefineSpaceSpecial_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_UndefineSpaceSpecial_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_UndefineSpaceSpecial(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX nvIndex,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_NV_UndefineSpaceSpecial(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_UndefineSpaceSpecial_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_Write.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Write.c
@@ -85,6 +85,17 @@ TSS2_RC Tss2_Sys_NV_Write_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_Write_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_Write(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
@@ -101,5 +112,9 @@ TSS2_RC Tss2_Sys_NV_Write(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_Write_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_NV_WriteLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_WriteLock.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_NV_WriteLock_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_NV_WriteLock_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_NV_WriteLock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_NV_WriteLock(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_NV_WriteLock_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PCR_Extend.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Extend.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_PCR_Extend_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PCR_Extend_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PCR_Extend(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
@@ -79,5 +90,9 @@ TSS2_RC Tss2_Sys_PCR_Extend(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PCR_Extend_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PCR_Reset.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Reset.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_PCR_Reset_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PCR_Reset_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PCR_Reset(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_PCR_Reset(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PCR_Reset_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PCR_SetAuthPolicy.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_SetAuthPolicy.c
@@ -86,6 +86,17 @@ TSS2_RC Tss2_Sys_PCR_SetAuthPolicy_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PCR_SetAuthPolicy_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PCR_SetAuthPolicy(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
@@ -102,5 +113,9 @@ TSS2_RC Tss2_Sys_PCR_SetAuthPolicy(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PCR_SetAuthPolicy_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PCR_SetAuthValue.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_SetAuthValue.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_PCR_SetAuthValue_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PCR_SetAuthValue_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PCR_SetAuthValue(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_PCR_SetAuthValue(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PCR_SetAuthValue_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PP_Commands.c
+++ b/sysapi/sysapi/Tss2_Sys_PP_Commands.c
@@ -69,6 +69,17 @@ TSS2_RC Tss2_Sys_PP_Commands_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PP_Commands_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PP_Commands(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM auth,
@@ -87,5 +98,9 @@ TSS2_RC Tss2_Sys_PP_Commands(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PP_Commands_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyAuthValue.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyAuthValue.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_PolicyAuthValue_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyAuthValue_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyAuthValue(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_PolicyAuthValue(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyAuthValue_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyAuthorize.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyAuthorize.c
@@ -93,6 +93,17 @@ TSS2_RC Tss2_Sys_PolicyAuthorize_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyAuthorize_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyAuthorize(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -115,5 +126,9 @@ TSS2_RC Tss2_Sys_PolicyAuthorize(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyAuthorize_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyCommandCode.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCommandCode.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_PolicyCommandCode_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyCommandCode_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyCommandCode(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_PolicyCommandCode(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyCommandCode_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyCounterTimer.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCounterTimer.c
@@ -86,6 +86,17 @@ TSS2_RC Tss2_Sys_PolicyCounterTimer_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyCounterTimer_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyCounterTimer(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -103,5 +114,9 @@ TSS2_RC Tss2_Sys_PolicyCounterTimer(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyCounterTimer_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyCpHash.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCpHash.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_PolicyCpHash_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyCpHash_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyCpHash(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_PolicyCpHash(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyCpHash_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyDuplicationSelect.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyDuplicationSelect.c
@@ -86,6 +86,17 @@ TSS2_RC Tss2_Sys_PolicyDuplicationSelect_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyDuplicationSelect_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyDuplicationSelect(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -104,5 +115,9 @@ TSS2_RC Tss2_Sys_PolicyDuplicationSelect(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyDuplicationSelect_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyLocality.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyLocality.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_PolicyLocality_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyLocality_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyLocality(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_PolicyLocality(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyLocality_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyNV.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNV.c
@@ -100,6 +100,17 @@ TSS2_RC Tss2_Sys_PolicyNV_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyNV_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyNV(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
@@ -120,5 +131,9 @@ TSS2_RC Tss2_Sys_PolicyNV(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyNV_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyNVWritten.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNVWritten.c
@@ -62,6 +62,16 @@ TSS2_RC Tss2_Sys_PolicyNvWritten_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyNVWritten_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
 
 TSS2_RC Tss2_Sys_PolicyNvWritten(
     TSS2_SYS_CONTEXT *sysContext,
@@ -77,5 +87,9 @@ TSS2_RC Tss2_Sys_PolicyNvWritten(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyNVWritten_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyNameHash.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNameHash.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_PolicyNameHash_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyNameHash_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyNameHash(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_PolicyNameHash(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyNameHash_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyOR.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyOR.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_PolicyOR_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyOR_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyOR(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -79,5 +90,9 @@ TSS2_RC Tss2_Sys_PolicyOR(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyOR_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyPCR.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPCR.c
@@ -79,6 +79,17 @@ TSS2_RC Tss2_Sys_PolicyPCR_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyPCR_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyPCR(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -97,5 +108,9 @@ TSS2_RC Tss2_Sys_PolicyPCR(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyPCR_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyPassword.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPassword.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_PolicyPassword_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyPassword_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyPassword(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_PolicyPassword(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyPassword_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyPhysicalPresence.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPhysicalPresence.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_PolicyPhysicalPresence_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyPhysicalPresence_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyPhysicalPresence(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_PolicyPhysicalPresence(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyPhysicalPresence_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyRestart.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyRestart.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_PolicyRestart_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyRestart_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyRestart(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY sessionHandle,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_PolicyRestart(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyRestart_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_PolicyTicket.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyTicket.c
@@ -100,6 +100,17 @@ TSS2_RC Tss2_Sys_PolicyTicket_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_PolicyTicket_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_PolicyTicket(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
@@ -122,5 +133,9 @@ TSS2_RC Tss2_Sys_PolicyTicket(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_PolicyTicket_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_SelfTest.c
+++ b/sysapi/sysapi/Tss2_Sys_SelfTest.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_SelfTest_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_SelfTest_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_SelfTest(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
@@ -68,6 +79,9 @@ TSS2_RC Tss2_Sys_SelfTest(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray,
-                                          rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_SelfTest_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_SequenceUpdate.c
+++ b/sysapi/sysapi/Tss2_Sys_SequenceUpdate.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_SequenceUpdate_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_SequenceUpdate_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_SequenceUpdate(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT sequenceHandle,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_SequenceUpdate(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_SequenceUpdate_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_SetAlgorithmSet.c
+++ b/sysapi/sysapi/Tss2_Sys_SetAlgorithmSet.c
@@ -62,6 +62,17 @@ TSS2_RC Tss2_Sys_SetAlgorithmSet_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_SetAlgorithmSet_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_SetAlgorithmSet(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
@@ -76,5 +87,9 @@ TSS2_RC Tss2_Sys_SetAlgorithmSet(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_SetAlgorithmSet_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_SetCommandCodeAuditStatus.c
+++ b/sysapi/sysapi/Tss2_Sys_SetCommandCodeAuditStatus.c
@@ -76,6 +76,17 @@ TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION auth,
@@ -96,5 +107,9 @@ TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_SetCommandCodeAuditStatus_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_SetPrimaryPolicy.c
+++ b/sysapi/sysapi/Tss2_Sys_SetPrimaryPolicy.c
@@ -79,6 +79,17 @@ TSS2_RC Tss2_Sys_SetPrimaryPolicy_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_SetPrimaryPolicy_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_SetPrimaryPolicy(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY_AUTH authHandle,
@@ -94,5 +105,9 @@ TSS2_RC Tss2_Sys_SetPrimaryPolicy(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_SetPrimaryPolicy_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_Shutdown.c
+++ b/sysapi/sysapi/Tss2_Sys_Shutdown.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_Shutdown_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_Shutdown_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_Shutdown(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_Shutdown(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_Shutdown_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_Startup.c
+++ b/sysapi/sysapi/Tss2_Sys_Startup.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_Startup_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_Startup_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_Startup(
     TSS2_SYS_CONTEXT *sysContext,
     TPM2_SU startupType)
@@ -66,5 +77,9 @@ TSS2_RC Tss2_Sys_Startup(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, 0, 0);
+    rval = CommonOneCall(ctx, 0, 0);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_Startup_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_StirRandom.c
+++ b/sysapi/sysapi/Tss2_Sys_StirRandom.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_StirRandom_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_StirRandom_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_StirRandom(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
@@ -68,5 +79,9 @@ TSS2_RC Tss2_Sys_StirRandom(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_StirRandom_Complete(sysContext);
 }

--- a/sysapi/sysapi/Tss2_Sys_TestParms.c
+++ b/sysapi/sysapi/Tss2_Sys_TestParms.c
@@ -55,6 +55,17 @@ TSS2_RC Tss2_Sys_TestParms_Prepare(
     return CommonPrepareEpilogue(ctx);
 }
 
+TSS2_RC Tss2_Sys_TestParms_Complete (
+    TSS2_SYS_CONTEXT *sysContext)
+{
+    _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
+
+    if (!ctx)
+        return TSS2_SYS_RC_BAD_REFERENCE;
+
+    return CommonComplete(ctx);
+}
+
 TSS2_RC Tss2_Sys_TestParms(
     TSS2_SYS_CONTEXT *sysContext,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
@@ -71,5 +82,9 @@ TSS2_RC Tss2_Sys_TestParms(
     if (rval)
         return rval;
 
-    return CommonOneCallForNoResponseCmds(ctx, cmdAuthsArray, rspAuthsArray);
+    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
+    if (rval)
+        return rval;
+
+    return Tss2_Sys_TestParms_Complete(sysContext);
 }

--- a/sysapi/sysapi/execute.c
+++ b/sysapi/sysapi/execute.c
@@ -40,7 +40,7 @@ TSS2_RC Tss2_Sys_ExecuteAsync(TSS2_SYS_CONTEXT *sysContext)
     if (ctx->previousStage != CMD_STAGE_PREPARE)
         return TSS2_SYS_RC_BAD_SEQUENCE;
 
-    rval = tss2_tcti_transmit(ctx->tctiContext,
+    rval = Tss2_Tcti_Transmit(ctx->tctiContext,
                               HOST_TO_BE_32(req_header_from_cxt(ctx)->commandSize),
                               ctx->cmdBuffer);
     if (rval)
@@ -65,7 +65,7 @@ TSS2_RC Tss2_Sys_ExecuteFinish(TSS2_SYS_CONTEXT *sysContext, int32_t timeout)
 
     responseSize = ctx->maxCmdSize;
 
-    rval = tss2_tcti_receive(ctx->tctiContext, &responseSize,
+    rval = Tss2_Tcti_Receive(ctx->tctiContext, &responseSize,
                              ctx->cmdBuffer, timeout);
     if (rval)
         return rval;

--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -201,17 +201,3 @@ TSS2_RC CommonOneCall(
 
     return rval;
 }
-
-TSS2_RC CommonOneCallForNoResponseCmds(
-    _TSS2_SYS_CONTEXT_BLOB *ctx,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
-{
-    TSS2_RC rval;
-
-    rval = CommonOneCall(ctx, cmdAuthsArray, rspAuthsArray);
-    if(rval)
-        return rval;
-
-    return CommonComplete(ctx);
-}

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -174,7 +174,7 @@ sapi_teardown_full (TSS2_SYS_CONTEXT *sapi_context)
     Tss2_Sys_Finalize (sapi_context);
     free (sapi_context);
     if (tcti_context) {
-        tss2_tcti_finalize (tcti_context);
+        Tss2_Tcti_Finalize (tcti_context);
         free (tcti_context);
     }
 }

--- a/test/tpmclient/tcti_util.c
+++ b/test/tpmclient/tcti_util.c
@@ -35,7 +35,7 @@ InitSocketTctiContext (const TCTI_SOCKET_CONF  *device_conf,
 void TeardownTctiContext(TSS2_TCTI_CONTEXT **tctiContext)
 {
     if (*tctiContext != NULL) {
-        tss2_tcti_finalize( *tctiContext );
+        Tss2_Tcti_Finalize( *tctiContext );
         free (*tctiContext);
         *tctiContext = NULL;
     }

--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -193,7 +193,7 @@ tcti_device_teardown (void **state)
 {
     TSS2_TCTI_CONTEXT *ctx = *state;
 
-    tss2_tcti_finalize (ctx);
+    Tss2_Tcti_Finalize (ctx);
     free (ctx);
     return 0;
 }
@@ -211,7 +211,7 @@ tcti_device_receive_success (void **state)
     TSS2_RC rc;
 
     will_return (__wrap_read, data->data_size);
-    rc = tss2_tcti_receive (data->ctx,
+    rc = Tss2_Tcti_Receive (data->ctx,
                             &data->buffer_size,
                             data->buffer,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -230,7 +230,7 @@ tcti_device_transmit_success (void **state)
     TSS2_RC rc;
 
     will_return (__wrap_write, data->buffer_size);
-    rc = tss2_tcti_transmit (data->ctx,
+    rc = Tss2_Tcti_Transmit (data->ctx,
                              data->buffer_size,
                              data->buffer);
     assert_true (rc == TSS2_RC_SUCCESS);

--- a/test/unit/tcti-socket.c
+++ b/test/unit/tcti-socket.c
@@ -325,7 +325,7 @@ tcti_socket_teardown (void **state)
 {
     TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT*)*state;
 
-    tss2_tcti_finalize (ctx);
+    Tss2_Tcti_Finalize (ctx);
     free (ctx);
     return 0;
 }
@@ -369,7 +369,7 @@ tcti_socket_receive_success_test (void **state)
     will_return (__wrap_recv, 4);
     will_return (__wrap_recv, platform_command_recv);
 
-    rc = tss2_tcti_receive (ctx, &response_size, response_out, TSS2_TCTI_TIMEOUT_BLOCK);
+    rc = Tss2_Tcti_Receive (ctx, &response_size, response_out, TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_memory_equal (response_in, response_out, response_size);
 }
@@ -395,7 +395,7 @@ tcti_socket_transmit_success_test (void **state)
     will_return (__wrap_send, 4);
     /* send the command buffer */
     will_return (__wrap_send, 0xc);
-    rc = tss2_tcti_transmit (ctx, command_size, command);
+    rc = Tss2_Tcti_Transmit (ctx, command_size, command);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 }
 


### PR DESCRIPTION
As per spec, we need to use CamelCase for tcti function macros.

The two patches change this for the header macros and for the tests.
It however leaves the lower-case version for compatibility until tools and resmgr are also updated.

This patchset applies ontop of #625 which is the reason for the third commit. Just ignore it.