### PR TITLE
tpm-types: Switch TPMAs from structs to defines

### DIFF
--- a/include/sapi/tpm20.h
+++ b/include/sapi/tpm20.h
@@ -31,8 +31,6 @@
 /* TSS2_VERSION_<CREATOR>_<FAMILY>_<LEVEL>_<REVISION> */
 #define TSS2_API_VERSION_1_1_1_1
 
-#define TPM_BITFIELD_LE
-
 #include    <stddef.h>
 #include    <stdint.h>
 #include    <stdlib.h>

--- a/marshal/tpma-types.c
+++ b/marshal/tpma-types.c
@@ -72,23 +72,23 @@ TSS2_RC Tss2_MU_##type##_Marshal(type src, uint8_t buffer[], \
          (uintptr_t)buffer, \
          local_offset); \
 \
-    switch (sizeof(src.val)) { \
+    switch (sizeof(src)) { \
         case 1: \
             break; \
         case 2: \
-            src.val = HOST_TO_BE_16(src.val); \
+            src = HOST_TO_BE_16(src); \
             break; \
         case 4: \
-            src.val = HOST_TO_BE_32(src.val); \
+            src = HOST_TO_BE_32(src); \
             break; \
         case 8: \
-            src.val = HOST_TO_BE_64(src.val); \
+            src = HOST_TO_BE_64(src); \
             break; \
 \
     } \
-    memcpy (&buffer [local_offset], &src, sizeof(src.val)); \
+    memcpy (&buffer [local_offset], &src, sizeof(src)); \
     if (offset != NULL) { \
-        *offset = local_offset + sizeof (src.val); \
+        *offset = local_offset + sizeof (src); \
         LOG (DEBUG, "offset parameter non-NULL, updated to %zu", *offset); \
     } \
 \
@@ -137,24 +137,24 @@ TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
 \
     memcpy (&tmp, &buffer [local_offset], sizeof (tmp)); \
 \
-    switch (sizeof(tmp.val)) { \
+    switch (sizeof(tmp)) { \
         case 1: \
-            dest->val = tmp.val; \
+            *dest = tmp; \
             break; \
         case 2: \
-            dest->val = BE_TO_HOST_16(tmp.val); \
+            *dest = BE_TO_HOST_16(tmp); \
             break; \
         case 4: \
-            dest->val = BE_TO_HOST_32(tmp.val); \
+            *dest = BE_TO_HOST_32(tmp); \
             break; \
         case 8: \
-            dest->val = BE_TO_HOST_64(tmp.val); \
+            *dest = BE_TO_HOST_64(tmp); \
             break; \
 \
     } \
 \
     if (offset != NULL) { \
-        *offset = local_offset + sizeof (dest->val); \
+        *offset = local_offset + sizeof (*dest); \
         LOG (DEBUG, "offset parameter non-NULL, updated to %zu", *offset); \
     } \
     return TSS2_RC_SUCCESS; \

--- a/sysapi/sysapi/authorizations.c
+++ b/sysapi/sysapi/authorizations.c
@@ -73,10 +73,10 @@ TSS2_RC Tss2_Sys_SetCmdAuths(
         authSize += sizeof(UINT8);
         authSize += sizeof(UINT16) + cmdAuthsArray->cmdAuths[i]->hmac.size;
 
-        if (cmdAuthsArray->cmdAuths[i]->sessionAttributes.decrypt)
+        if (cmdAuthsArray->cmdAuths[i]->sessionAttributes & TPMA_SESSION_DECRYPT)
             ctx->decryptSession = 1;
 
-        if (cmdAuthsArray->cmdAuths[i]->sessionAttributes.encrypt)
+        if (cmdAuthsArray->cmdAuths[i]->sessionAttributes & TPMA_SESSION_ENCRYPT)
             ctx->encryptSession = 1;
     }
 

--- a/test/integration/asymmetric-encrypt-decrypt.int.c
+++ b/test/integration/asymmetric-encrypt-decrypt.int.c
@@ -62,12 +62,12 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     in_public.publicArea.type = TPM2_ALG_RSA;
     in_public.publicArea.nameAlg = TPM2_ALG_SHA256;
     *(UINT32 *)&(in_public.publicArea.objectAttributes) = 0;
-    in_public.publicArea.objectAttributes.restricted = 1;
-    in_public.publicArea.objectAttributes.userWithAuth = 1;
-    in_public.publicArea.objectAttributes.decrypt = 1;
-    in_public.publicArea.objectAttributes.fixedTPM = 1;
-    in_public.publicArea.objectAttributes.fixedParent = 1;
-    in_public.publicArea.objectAttributes.sensitiveDataOrigin = 1;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_RESTRICTED;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
 
     in_public.publicArea.authPolicy.size = 0;
 
@@ -100,13 +100,12 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 
     // First clear attributes bit field.
     *(UINT32 *)&(in_public.publicArea.objectAttributes) = 0;
-    in_public.publicArea.objectAttributes.restricted = 0;
-    in_public.publicArea.objectAttributes.userWithAuth = 1;
-    in_public.publicArea.objectAttributes.decrypt = 1;
-    in_public.publicArea.objectAttributes.sign = 1;
-    in_public.publicArea.objectAttributes.fixedTPM = 1;
-    in_public.publicArea.objectAttributes.fixedParent = 1;
-    in_public.publicArea.objectAttributes.sensitiveDataOrigin = 1;
+    in_public.publicArea.objectAttributes &= ~TPMA_OBJECT_RESTRICTED;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
 
     outside_info.size = 0;
     out_public.size = 0;

--- a/test/integration/create-keyedhash-sha1-hmac.int.c
+++ b/test/integration/create-keyedhash-sha1-hmac.int.c
@@ -44,8 +44,8 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 
     inPublic.publicArea.nameAlg = TPM2_ALG_SHA1;
     inPublic.publicArea.type = TPM2_ALG_KEYEDHASH;
-    inPublic.publicArea.objectAttributes.sign = 1;
-    inPublic.publicArea.objectAttributes.sensitiveDataOrigin = 1;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_SIGN;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
     inPublic.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_HMAC;
     inPublic.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg = TPM2_ALG_SHA1;
 

--- a/test/integration/sapi-util.c
+++ b/test/integration/sapi-util.c
@@ -68,12 +68,12 @@ create_primary_rsa_2048_aes_128_cfb (
     }
     in_public.publicArea.type = TPM2_ALG_RSA;
     in_public.publicArea.nameAlg = TPM2_ALG_SHA256;
-    in_public.publicArea.objectAttributes.restricted = 1;
-    in_public.publicArea.objectAttributes.userWithAuth = 1;
-    in_public.publicArea.objectAttributes.decrypt = 1;
-    in_public.publicArea.objectAttributes.fixedTPM = 1;
-    in_public.publicArea.objectAttributes.fixedParent = 1;
-    in_public.publicArea.objectAttributes.sensitiveDataOrigin = 1;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_RESTRICTED;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
     in_public.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM2_ALG_AES;
     in_public.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
     in_public.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM2_ALG_CFB;
@@ -116,13 +116,12 @@ create_aes_128_cfb (
     TPM2B_PUBLIC            in_public       = {
             .publicArea.type = TPM2_ALG_SYMCIPHER,
             .publicArea.nameAlg = TPM2_ALG_SHA256,
-            .publicArea.objectAttributes = {
-                .decrypt = 1,
-                .fixedTPM = 1,
-                .fixedParent = 1,
-                .sensitiveDataOrigin = 1,
-                .sign = 1,
-                .userWithAuth = 1, },
+            .publicArea.objectAttributes = TPMA_OBJECT_DECRYPT |
+                                           TPMA_OBJECT_FIXEDTPM |
+                                           TPMA_OBJECT_FIXEDPARENT |
+                                           TPMA_OBJECT_SENSITIVEDATAORIGIN |
+                                           TPMA_OBJECT_SIGN |
+                                           TPMA_OBJECT_USERWITHAUTH,
             .publicArea.parameters.symDetail.sym = {
                 .algorithm = TPM2_ALG_AES,
                 .keyBits.sym = 128,

--- a/test/tpmclient/DecryptEncrypt.c
+++ b/test/tpmclient/DecryptEncrypt.c
@@ -109,9 +109,9 @@ UINT32 LoadSessionEncryptDecryptKey( TPMT_SYM_DEF *symmetric, TPM2B_MAX_BUFFER *
     inPublic.publicArea.type = TPM2_ALG_SYMCIPHER;
     inPublic.publicArea.nameAlg = TPM2_ALG_NULL;
     *( UINT32 *)&( inPublic.publicArea.objectAttributes )= 0;
-    inPublic.publicArea.objectAttributes.decrypt = 1;
-    inPublic.publicArea.objectAttributes.sign = 1;
-    inPublic.publicArea.objectAttributes.userWithAuth = 1;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_SIGN;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
     inPublic.publicArea.authPolicy.size = 0;
     inPublic.publicArea.parameters.symDetail.sym.algorithm = symmetric->algorithm;
     inPublic.publicArea.parameters.symDetail.sym.keyBits = symmetric->keyBits;

--- a/test/tpmclient/LoadExternalHMACKey.c
+++ b/test/tpmclient/LoadExternalHMACKey.c
@@ -49,8 +49,8 @@ UINT32 LoadExternalHMACKey( TPMI_ALG_HASH hashAlg, TPM2B *key, TPM2_HANDLE *keyH
     inPublic.publicArea.type = TPM2_ALG_KEYEDHASH;
     inPublic.publicArea.nameAlg = TPM2_ALG_NULL;
     *( UINT32 *)&( inPublic.publicArea.objectAttributes )= 0;
-    inPublic.publicArea.objectAttributes.sign = 1;
-    inPublic.publicArea.objectAttributes.userWithAuth = 1;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_SIGN;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
     inPublic.publicArea.authPolicy.size = 0;
     inPublic.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_HMAC;
     inPublic.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg = hashAlg;

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -944,11 +944,11 @@ void TestNV()
     *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
 
     // Now set the attributes.
-    publicInfo.nvPublic.attributes.TPMA_NV_PPREAD = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_PPWRITE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_WRITE_STCLEAR = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_PLATFORMCREATE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_ORDERLY = 1;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_PPREAD;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_PPWRITE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_WRITE_STCLEAR;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_ORDERLY;
     publicInfo.nvPublic.authPolicy.size = 0;
     publicInfo.nvPublic.dataSize = 32;
 
@@ -1031,12 +1031,12 @@ void TestNV()
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 0 );
     CheckPassed( rval );
 
-    publicInfo.nvPublic.attributes.TPMA_NV_PPREAD = 0;
-    publicInfo.nvPublic.attributes.TPMA_NV_PPWRITE = 0;
-    publicInfo.nvPublic.attributes.TPMA_NV_OWNERREAD = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_OWNERWRITE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_PLATFORMCREATE = 0;
-    publicInfo.nvPublic.attributes.TPMA_NV_ORDERLY = 1;
+    publicInfo.nvPublic.attributes &= ~TPMA_NV_TPMA_NV_PPREAD;
+    publicInfo.nvPublic.attributes &= ~TPMA_NV_TPMA_NV_PPWRITE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_OWNERREAD;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_OWNERWRITE;
+    publicInfo.nvPublic.attributes &= ~TPMA_NV_TPMA_NV_PLATFORMCREATE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_ORDERLY;
     publicInfo.nvPublic.nvIndex = TPM20_INDEX_TEST2;
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM2_RH_OWNER, &sessionsData, &nvAuth, &publicInfo, 0 );
     CheckPassed( rval );
@@ -1104,12 +1104,12 @@ void TestHierarchyControl()
     *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
 
     // Now set the attributes.
-    publicInfo.nvPublic.attributes.TPMA_NV_PPREAD = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_PPWRITE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_PPWRITE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_WRITE_STCLEAR = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_PLATFORMCREATE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_ORDERLY = 1;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_PPREAD;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_PPWRITE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_PPWRITE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_WRITE_STCLEAR;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_ORDERLY;
     publicInfo.nvPublic.authPolicy.size = 0;
     publicInfo.nvPublic.dataSize = 32;
 
@@ -1211,12 +1211,12 @@ void TestCreate(){
 
     // First clear attributes bit field.
     *(UINT32 *)&( inPublic.publicArea.objectAttributes) = 0;
-    inPublic.publicArea.objectAttributes.restricted = 1;
-    inPublic.publicArea.objectAttributes.userWithAuth = 1;
-    inPublic.publicArea.objectAttributes.decrypt = 1;
-    inPublic.publicArea.objectAttributes.fixedTPM = 1;
-    inPublic.publicArea.objectAttributes.fixedParent = 1;
-    inPublic.publicArea.objectAttributes.sensitiveDataOrigin = 1;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_RESTRICTED;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
 
     inPublic.publicArea.authPolicy.size = 0;
 
@@ -1288,8 +1288,8 @@ void TestCreate(){
     sessionData.hmac.buffer[1] = 0xff;
 
     inPublic.publicArea.type = TPM2_ALG_KEYEDHASH;
-    inPublic.publicArea.objectAttributes.decrypt = 0;
-    inPublic.publicArea.objectAttributes.sign = 1;
+    inPublic.publicArea.objectAttributes &= ~TPMA_OBJECT_DECRYPT;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_SIGN;
 
     inPublic.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_HMAC;
     inPublic.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg = TPM2_ALG_SHA1;
@@ -1375,7 +1375,7 @@ TSS2_RC DefineNvIndex( TPMI_RH_PROVISION authHandle, TPMI_SH_AUTH_SESSION sessio
     // Init session attributes
     *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
 
-    attributes.TPMA_NV_ORDERLY = 1;
+    attributes |= TPMA_NV_TPMA_NV_ORDERLY;
 
     // Init public info structure.
     publicInfo.nvPublic.attributes = attributes;
@@ -1467,7 +1467,7 @@ TSS2_RC CreateNVIndex( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TP
 
     // Send PolicyLocality command
     *(UINT8 *)( (void *)&locality ) = 0;
-    locality.TPM2_LOC_THREE = 1;
+    locality |= TPMA_LOCALITY_TPM2_LOC_THREE;
     rval = Tss2_Sys_PolicyLocality( sysContext, (*policySession)->sessionHandle,
             0, locality, 0 );
     CheckPassed( rval );
@@ -1482,9 +1482,9 @@ TSS2_RC CreateNVIndex( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TP
 
     // Now set the attributes.
     *(UINT32 *)( (void *)&nvAttributes ) = 0;
-    nvAttributes.TPMA_NV_POLICYREAD = 1;
-    nvAttributes.TPMA_NV_POLICYWRITE = 1;
-    nvAttributes.TPMA_NV_PLATFORMCREATE = 1;
+    nvAttributes |= TPMA_NV_TPMA_NV_POLICYREAD;
+    nvAttributes |= TPMA_NV_TPMA_NV_POLICYWRITE;
+    nvAttributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
 
     rval = DefineNvIndex( TPM2_RH_PLATFORM, TPM2_RS_PW, &nvAuth, policyDigest,
             TPM20_INDEX_PASSWORD_TEST, TPM2_ALG_SHA256, nvAttributes, 32  );
@@ -1524,7 +1524,7 @@ TSS2_RC TestLocality( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
     sessionsData.cmdAuths[0]->hmac.size = 0;
 
     *(UINT8 *)( (void *)&( sessionsData.cmdAuths[0]->sessionAttributes ) ) = 0;
-     sessionsData.cmdAuths[0]->sessionAttributes.continueSession = 1;
+     sessionsData.cmdAuths[0]->sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
 
     rval = SetLocality( sysContext, 2 );
     CheckPassed( rval );
@@ -1664,12 +1664,12 @@ TSS2_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, T
     inPublic.publicArea.type = TPM2_ALG_RSA;
     inPublic.publicArea.nameAlg = TPM2_ALG_SHA1;
     *(UINT32 *)&( inPublic.publicArea.objectAttributes) = 0;
-    inPublic.publicArea.objectAttributes.restricted = 1;
-    inPublic.publicArea.objectAttributes.userWithAuth = 1;
-    inPublic.publicArea.objectAttributes.decrypt = 1;
-    inPublic.publicArea.objectAttributes.fixedTPM = 1;
-    inPublic.publicArea.objectAttributes.fixedParent = 1;
-    inPublic.publicArea.objectAttributes.sensitiveDataOrigin = 1;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_RESTRICTED;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_DECRYPT;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDTPM;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_FIXEDPARENT;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
     inPublic.publicArea.authPolicy.size = 0;
     inPublic.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM2_ALG_AES;
     inPublic.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
@@ -1701,9 +1701,9 @@ TSS2_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, T
 
     inPublic.publicArea.type = TPM2_ALG_KEYEDHASH;
     inPublic.publicArea.nameAlg = TPM2_ALG_SHA256;
-    inPublic.publicArea.objectAttributes.restricted = 0;
-    inPublic.publicArea.objectAttributes.decrypt = 0;
-    inPublic.publicArea.objectAttributes.sensitiveDataOrigin = 0;
+    inPublic.publicArea.objectAttributes &= ~TPMA_OBJECT_RESTRICTED;
+    inPublic.publicArea.objectAttributes &= ~TPMA_OBJECT_DECRYPT;
+    inPublic.publicArea.objectAttributes &= ~TPMA_OBJECT_SENSITIVEDATAORIGIN;
     CopySizedByteBuffer((TPM2B *)&inPublic.publicArea.authPolicy, (TPM2B *)policyDigest);
     inPublic.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_NULL;
     inPublic.publicArea.unique.keyedHash.size = 0;
@@ -1737,7 +1737,7 @@ TSS2_RC AuthValueUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
     cmdAuth.sessionHandle = policySession->sessionHandle;
     cmdAuth.nonce.size = 0;
     *( (UINT8 *)((void *)&cmdAuth.sessionAttributes ) ) = 0;
-    cmdAuth.sessionAttributes.continueSession = 1;
+    cmdAuth.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
     cmdAuth.hmac.size = 0;
 
     // Now try to unseal the blob without setting the HMAC.
@@ -1798,7 +1798,7 @@ TSS2_RC PasswordUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
     cmdAuth.sessionHandle = policySession->sessionHandle;
     cmdAuth.nonce.size = 0;
     *( (UINT8 *)((void *)&cmdAuth.sessionAttributes ) ) = 0;
-    cmdAuth.sessionAttributes.continueSession = 1;
+    cmdAuth.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
     cmdAuth.hmac.size = 0;
 
     // Now try to unseal the blob without setting the password.
@@ -2195,13 +2195,13 @@ void ProvisionOtherIndices()
     *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
 
     // Now set the attributes.
-    publicInfo.nvPublic.attributes.TPMA_NV_AUTHREAD = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_AUTHWRITE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_PLATFORMCREATE = 1;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_AUTHREAD;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_AUTHWRITE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
     // Following commented out for convenience during development.
-    // publicInfo.nvPublic.attributes.TPMA_NV_POLICY_DELETE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_WRITEDEFINE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_ORDERLY = 1;
+    // publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_POLICY_DELETE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_WRITEDEFINE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_ORDERLY;
 
     publicInfo.nvPublic.authPolicy.size = 0;
     publicInfo.nvPublic.dataSize = NV_PS_INDEX_SIZE;
@@ -2234,8 +2234,8 @@ TSS2_RC InitNvAuxPolicySession( TPMI_SH_AUTH_SESSION *nvAuxPolicySessionHandle )
 
     // 2.  PolicyLocality(3)
     *(UINT8 *)((void *)&locality) = 0;
-    locality.TPM2_LOC_THREE = 1;
-    locality.TPM2_LOC_FOUR = 1;
+    locality |= TPMA_LOCALITY_TPM2_LOC_THREE;
+    locality |= TPMA_LOCALITY_TPM2_LOC_FOUR;
     rval = Tss2_Sys_PolicyLocality( sysContext, *nvAuxPolicySessionHandle, 0, locality, 0 );
 
     return( rval );
@@ -2314,9 +2314,9 @@ void ProvisionNvAux()
     *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
 
     // Now set the attributes.
-    publicInfo.nvPublic.attributes.TPMA_NV_AUTHREAD = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_POLICYWRITE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_PLATFORMCREATE = 1;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_AUTHREAD;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_POLICYWRITE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
     // Following commented out for convenience during development.
     // publicInfo.nvPublic.attributes.TPMA_NV_POLICY_DELETE = 1;
 
@@ -2353,7 +2353,7 @@ void TpmAuxWrite( int locality)
     nullSessionData.sessionHandle = nvAuxPolicyAuthHandle;
 
     // Make sure that session terminates after NVWrite completes.
-    nullSessionData.sessionAttributes.continueSession = 0;
+    nullSessionData.sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     rval = SetLocality( sysContext, locality );
     CheckPassed( rval );
@@ -2394,7 +2394,7 @@ void TpmAuxReadWriteTest()
 
     DebugPrintf( NO_PREFIX, "TPM AUX READ/WRITE TEST\n" );
 
-    nullSessionData.sessionAttributes.continueSession = 0;
+    nullSessionData.sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     // Try writing it from all localities.  Only locality 3 should work.
     for( testLocality = 0; testLocality < 5; testLocality++ )
@@ -2620,7 +2620,7 @@ void TestUnseal()
     inPublic.publicArea.nameAlg = TPM2_ALG_SHA1;
 
     *(UINT32 *)&( inPublic.publicArea.objectAttributes) = 0;
-    inPublic.publicArea.objectAttributes.userWithAuth = 1;
+    inPublic.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
 
     inPublic.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_NULL;
 
@@ -2717,10 +2717,10 @@ void CreatePasswordTestNV( TPMI_RH_NV_INDEX nvIndex, char * password )
     *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
 
     // Now set the attributes.
-    publicInfo.nvPublic.attributes.TPMA_NV_AUTHREAD = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_AUTHWRITE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_PLATFORMCREATE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_ORDERLY = 1;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_AUTHREAD;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_AUTHWRITE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_ORDERLY;
     publicInfo.nvPublic.authPolicy.size = 0;
     publicInfo.nvPublic.dataSize = 32;
 
@@ -2898,9 +2898,9 @@ void SimplePolicyTest()
     // Now set the NV index's attributes:
     // policyRead, authWrite, and platormCreate.
     *(UINT32 *)( (void *)&nvAttributes ) = 0;
-    nvAttributes.TPMA_NV_POLICYREAD = 1;
-    nvAttributes.TPMA_NV_POLICYWRITE = 1;
-    nvAttributes.TPMA_NV_PLATFORMCREATE = 1;
+    nvAttributes |= TPMA_NV_TPMA_NV_POLICYREAD;
+    nvAttributes |= TPMA_NV_TPMA_NV_POLICYWRITE;
+    nvAttributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
 
     // Create the NV index.
     rval = DefineNvIndex( TPM2_RH_PLATFORM, TPM2_RS_PW,
@@ -2977,7 +2977,7 @@ void SimplePolicyTest()
     nvCmdAuths.cmdAuths[0]->nonce.buffer[0] = 0xa5;
     *( (UINT8 *)((void *)&sessionAttributes ) ) = 0;
     nvCmdAuths.cmdAuths[0]->sessionAttributes = sessionAttributes;
-    nvCmdAuths.cmdAuths[0]->sessionAttributes.continueSession = 1;
+    nvCmdAuths.cmdAuths[0]->sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
 
     // Roll nonces for command
     RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
@@ -3025,7 +3025,7 @@ void SimplePolicyTest()
     RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
 
     // End the session after next command.
-    nvCmdAuths.cmdAuths[0]->sessionAttributes.continueSession = 0;
+    nvCmdAuths.cmdAuths[0]->sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
@@ -3137,9 +3137,9 @@ void SimpleHmacTest()
     // Now set the NV index's attributes:
     // policyRead, authWrite, and platormCreate.
     *(UINT32 *)( (void *)&nvAttributes ) = 0;
-    nvAttributes.TPMA_NV_AUTHREAD = 1;
-    nvAttributes.TPMA_NV_AUTHWRITE = 1;
-    nvAttributes.TPMA_NV_PLATFORMCREATE = 1;
+    nvAttributes |= TPMA_NV_TPMA_NV_AUTHREAD;
+    nvAttributes |= TPMA_NV_TPMA_NV_AUTHWRITE;
+    nvAttributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
 
     // Create the NV index.
     rval = DefineNvIndex( TPM2_RH_PLATFORM, TPM2_RS_PW,
@@ -3208,7 +3208,7 @@ void SimpleHmacTest()
     nvCmdAuths.cmdAuths[0]->nonce.buffer[0] = 0xa5;
     *( (UINT8 *)(&sessionAttributes ) ) = 0;
     nvCmdAuths.cmdAuths[0]->sessionAttributes = sessionAttributes;
-    nvCmdAuths.cmdAuths[0]->sessionAttributes.continueSession = 1;
+    nvCmdAuths.cmdAuths[0]->sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
 
     // Roll nonces for command
     RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
@@ -3253,7 +3253,7 @@ void SimpleHmacTest()
     RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
 
     // End the session after next command.
-    nvCmdAuths.cmdAuths[0]->sessionAttributes.continueSession = 0;
+    nvCmdAuths.cmdAuths[0]->sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
@@ -3441,15 +3441,15 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     *(UINT32 *)( &nvAttributes ) = 0;
     if( hmacTest )
     {
-        nvAttributes.TPMA_NV_AUTHREAD = 1;
-        nvAttributes.TPMA_NV_AUTHWRITE = 1;
+        nvAttributes |= TPMA_NV_TPMA_NV_AUTHREAD;
+        nvAttributes |= TPMA_NV_TPMA_NV_AUTHWRITE;
     }
     else
     {
-        nvAttributes.TPMA_NV_POLICYREAD = 1;
-        nvAttributes.TPMA_NV_POLICYWRITE = 1;
+        nvAttributes |= TPMA_NV_TPMA_NV_POLICYREAD;
+        nvAttributes |= TPMA_NV_TPMA_NV_POLICYWRITE;
     }
-    nvAttributes.TPMA_NV_PLATFORMCREATE = 1;
+    nvAttributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
 
     // Create the NV index.
     rval = DefineNvIndex( TPM2_RH_PLATFORM, TPM2_RS_PW,
@@ -3535,7 +3535,7 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     nvCmdAuths.cmdAuths[0]->nonce.buffer[0] = 0xa5;
     *( (UINT8 *)(&sessionAttributes ) ) = 0;
     nvCmdAuths.cmdAuths[0]->sessionAttributes = sessionAttributes;
-    nvCmdAuths.cmdAuths[0]->sessionAttributes.continueSession = 1;
+    nvCmdAuths.cmdAuths[0]->sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
 
     // Roll nonces for command
     RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
@@ -3588,7 +3588,7 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
 
     // End the session after next command.
-    nvCmdAuths.cmdAuths[0]->sessionAttributes.continueSession = 0;
+    nvCmdAuths.cmdAuths[0]->sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
@@ -3702,9 +3702,9 @@ void TestEncryptDecryptSession()
 
     // Create NV index with empty auth value.
     *(UINT32 *)( (void *)&nvAttributes ) = 0;
-    nvAttributes.TPMA_NV_AUTHREAD = 1;
-    nvAttributes.TPMA_NV_AUTHWRITE = 1;
-    nvAttributes.TPMA_NV_PLATFORMCREATE = 1;
+    nvAttributes |= TPMA_NV_TPMA_NV_AUTHREAD;
+    nvAttributes |= TPMA_NV_TPMA_NV_AUTHWRITE;
+    nvAttributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
 
     // No authorization required.
     authPolicy.size = 0;
@@ -3809,9 +3809,9 @@ void TestEncryptDecryptSession()
         *( (UINT8 *)((void *)&sessionAttributes ) ) = 0;
         decryptEncryptSessionCmdAuth.sessionAttributes =
                 sessionAttributes;
-        decryptEncryptSessionCmdAuth.sessionAttributes.continueSession
-                = 1;
-        decryptEncryptSessionCmdAuth.sessionAttributes.decrypt = 1;
+        decryptEncryptSessionCmdAuth.sessionAttributes |= 
+                TPMA_SESSION_CONTINUESESSION;
+        decryptEncryptSessionCmdAuth.sessionAttributes |= TPMA_SESSION_DECRYPT;
         decryptEncryptSessionCmdAuth.hmac.size = 0;
 
         rval = Tss2_Sys_SetCmdAuths( sysContext, &nvRdWrCmdAuths );
@@ -3910,10 +3910,10 @@ void TestEncryptDecryptSession()
         RollNonces( encryptDecryptSession,
                 &decryptEncryptSessionCmdAuth.nonce );
 
-        decryptEncryptSessionCmdAuth.sessionAttributes.decrypt = 0;
-        decryptEncryptSessionCmdAuth.sessionAttributes.encrypt = 1;
-        decryptEncryptSessionCmdAuth.sessionAttributes.continueSession =
-                1;
+        decryptEncryptSessionCmdAuth.sessionAttributes &= ~TPMA_SESSION_DECRYPT;
+        decryptEncryptSessionCmdAuth.sessionAttributes |= TPMA_SESSION_ENCRYPT;
+        decryptEncryptSessionCmdAuth.sessionAttributes |= 
+                TPMA_SESSION_CONTINUESESSION;
 
         rval = Tss2_Sys_SetCmdAuths( sysContext, &nvRdWrCmdAuths );
         CheckPassed( rval );
@@ -4261,9 +4261,9 @@ void GetSetEncryptParamTests()
 
     // Now set the attributes.
     *(UINT32 *)( (void *)&nvAttributes ) = 0;
-    nvAttributes.TPMA_NV_AUTHREAD = 1;
-    nvAttributes.TPMA_NV_AUTHWRITE = 1;
-    nvAttributes.TPMA_NV_PLATFORMCREATE = 1;
+    nvAttributes |= TPMA_NV_TPMA_NV_AUTHREAD;
+    nvAttributes |= TPMA_NV_TPMA_NV_AUTHWRITE;
+    nvAttributes |= TPMA_NV_TPMA_NV_PLATFORMCREATE;
 
     rval = DefineNvIndex( TPM2_RH_PLATFORM, TPM2_RS_PW, &nvAuth, &authPolicy,
             TPM20_INDEX_PASSWORD_TEST, TPM2_ALG_SHA1, nvAttributes, 32  );

--- a/test/unit/TPMA-marshal.c
+++ b/test/unit/TPMA-marshal.c
@@ -22,22 +22,22 @@ tpma_marshal_success(void **state)
     uint8_t session_expected = TPMA_SESSION_AUDIT | TPMA_SESSION_AUDITRESET | TPMA_SESSION_DECRYPT;
     TSS2_RC rc;
 
-    alg.asymmetric = 1;
-    alg.signing = 1;
+    alg |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg |= TPMA_ALGORITHM_SIGNING;
     ptr = (TPMA_ALGORITHM *)buffer;
 
     rc = Tss2_MU_TPMA_ALGORITHM_Marshal(alg, buffer, buffer_size, NULL);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (ptr->val, alg_expected);
+    assert_int_equal (*ptr, alg_expected);
 
-    session.audit = 1;
-    session.decrypt = 1;
-    session.auditReset = 1;
+    session |= TPMA_SESSION_AUDIT;
+    session |= TPMA_SESSION_DECRYPT;
+    session |= TPMA_SESSION_AUDITRESET;
     ptr2 = (TPMA_SESSION *)buffer2;
 
     rc = Tss2_MU_TPMA_SESSION_Marshal(session, buffer2, buffer_size2, NULL);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (ptr2->val, session_expected);
+    assert_int_equal (*ptr2, session_expected);
 }
 
 /*
@@ -57,23 +57,23 @@ tpma_marshal_success_offset(void **state)
     uint8_t session_expected = TPMA_SESSION_AUDIT | TPMA_SESSION_AUDITRESET | TPMA_SESSION_DECRYPT;
     TSS2_RC rc;
 
-    alg.asymmetric = 1;
-    alg.signing = 1;
+    alg |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg |= TPMA_ALGORITHM_SIGNING;
     ptr = (TPMA_ALGORITHM *)&buffer[10];
 
     rc = Tss2_MU_TPMA_ALGORITHM_Marshal(alg, buffer, buffer_size, &offset);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (ptr->val, alg_expected);
+    assert_int_equal (*ptr, alg_expected);
     assert_int_equal (offset, sizeof (buffer));
 
-    session.audit = 1;
-    session.decrypt = 1;
-    session.auditReset = 1;
+    session |= TPMA_SESSION_AUDIT;
+    session |= TPMA_SESSION_DECRYPT;
+    session |= TPMA_SESSION_AUDITRESET;
     ptr2 = (TPMA_SESSION *)&buffer2[14];
 
     rc = Tss2_MU_TPMA_SESSION_Marshal(session, buffer2, buffer_size2, &offset);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (ptr2->val, session_expected);
+    assert_int_equal (*ptr2, session_expected);
     assert_int_equal (offset, sizeof (buffer2));
 }
 
@@ -88,16 +88,16 @@ tpma_marshal_buffer_null_with_offset(void **state)
     size_t offset = 100;
     TSS2_RC rc;
 
-    alg.asymmetric = 1;
-    alg.signing = 1;
+    alg |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg |= TPMA_ALGORITHM_SIGNING;
 
     rc = Tss2_MU_TPMA_ALGORITHM_Marshal(alg, NULL, sizeof(alg), &offset);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (offset, 100 + sizeof(alg));
 
-    session.audit = 1;
-    session.decrypt = 1;
-    session.auditReset = 1;
+    session |= TPMA_SESSION_AUDIT;
+    session |= TPMA_SESSION_DECRYPT;
+    session |= TPMA_SESSION_AUDITRESET;
     offset = 100;
 
     rc = Tss2_MU_TPMA_SESSION_Marshal(session, NULL, sizeof(session), &offset);
@@ -115,15 +115,15 @@ tpma_marshal_buffer_null_offset_null(void **state)
     TPMA_SESSION session = {0};
     TSS2_RC rc;
 
-    alg.asymmetric = 1;
-    alg.signing = 1;
+    alg |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg |= TPMA_ALGORITHM_SIGNING;
 
     rc = Tss2_MU_TPMA_ALGORITHM_Marshal(alg, NULL, sizeof(alg), NULL);
     assert_int_equal (rc, TSS2_TYPES_RC_BAD_REFERENCE);
 
-    session.audit = 1;
-    session.decrypt = 1;
-    session.auditReset = 1;
+    session |= TPMA_SESSION_AUDIT;
+    session |= TPMA_SESSION_DECRYPT;
+    session |= TPMA_SESSION_AUDITRESET;
 
     rc = Tss2_MU_TPMA_SESSION_Marshal(session, NULL, sizeof(session), NULL);
     assert_int_equal (rc, TSS2_TYPES_RC_BAD_REFERENCE);
@@ -144,16 +144,16 @@ tpma_marshal_buffer_size_lt_data_nad_lt_offset(void **state)
     size_t offset = 2;
     TSS2_RC rc;
 
-    alg.asymmetric = 1;
-    alg.signing = 1;
+    alg |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg |= TPMA_ALGORITHM_SIGNING;
 
     rc = Tss2_MU_TPMA_ALGORITHM_Marshal(alg, buffer, buffer_size, &offset);
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, 2);
 
-    session.audit = 1;
-    session.decrypt = 1;
-    session.auditReset = 1;
+    session |= TPMA_SESSION_AUDIT;
+    session |= TPMA_SESSION_DECRYPT;
+    session |= TPMA_SESSION_AUDITRESET;
 
     rc = Tss2_MU_TPMA_SESSION_Marshal(session, buffer2, buffer_size2, &offset);
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
@@ -185,13 +185,13 @@ tpma_unmarshal_success(void **state)
 
     rc = Tss2_MU_TPMA_ALGORITHM_Unmarshal(buffer, buffer_size, &offset, &alg);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (alg.val, BE_TO_HOST_32(alg_expected));
+    assert_int_equal (alg, BE_TO_HOST_32(alg_expected));
     assert_int_equal (offset, 4);
 
 
     rc = Tss2_MU_TPMA_SESSION_Unmarshal(buffer, buffer_size, &offset, &session);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (session.val, session_expected);
+    assert_int_equal (session, session_expected);
     assert_int_equal (offset, 5);
 }
 
@@ -257,16 +257,16 @@ tpma_unmarshal_dest_null_offset_valid(void **state)
     *ptr = alg_expected;
     *ptr2 = session_expected;
 
-    alg.asymmetric = 1;
-    alg.signing = 1;
+    alg |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg |= TPMA_ALGORITHM_SIGNING;
 
     rc = Tss2_MU_TPMA_ALGORITHM_Unmarshal(buffer, buffer_size, &offset, NULL);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (offset, sizeof(alg));
 
-    session.audit = 1;
-    session.decrypt = 1;
-    session.auditReset = 1;
+    session |= TPMA_SESSION_AUDIT;
+    session |= TPMA_SESSION_DECRYPT;
+    session |= TPMA_SESSION_AUDITRESET;
 
     rc = Tss2_MU_TPMA_SESSION_Unmarshal(buffer, buffer_size, &offset, NULL);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
@@ -284,16 +284,16 @@ tpma_unmarshal_buffer_size_lt_data_nad_lt_offset(void **state)
     size_t offset = 1;
     TSS2_RC rc;
 
-    alg.asymmetric = 1;
-    alg.signing = 1;
+    alg |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg |= TPMA_ALGORITHM_SIGNING;
 
     rc = Tss2_MU_TPMA_ALGORITHM_Unmarshal(buffer, sizeof(alg), &offset, &alg);
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, 1);
 
-    session.audit = 1;
-    session.decrypt = 1;
-    session.auditReset = 1;
+    session |= TPMA_SESSION_AUDIT;
+    session |= TPMA_SESSION_DECRYPT;
+    session |= TPMA_SESSION_AUDITRESET;
 
     rc = Tss2_MU_TPMA_SESSION_Unmarshal(buffer, 1, &offset, &session);
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);

--- a/test/unit/TPMS-marshal.c
+++ b/test/unit/TPMS-marshal.c
@@ -27,8 +27,8 @@ tpms_marshal_success(void **state)
     TSS2_RC rc;
 
     alg.alg = TPM2_ALG_ECDSA;
-    alg.algProperties.asymmetric = 1;
-    alg.algProperties.signing = 1;
+    alg.algProperties |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg.algProperties |= TPMA_ALGORITHM_SIGNING;
     alg_ptr = (uint16_t *)buffer;
     alg_properties_ptr = (uint32_t *)(buffer + sizeof(uint16_t));
     rc = Tss2_MU_TPMS_ALG_PROPERTY_Marshal(&alg, buffer, buffer_size, NULL);
@@ -72,8 +72,8 @@ tpms_marshal_success_offset(void **state)
     TSS2_RC rc;
 
     alg.alg = TPM2_ALG_ECDSA;
-    alg.algProperties.asymmetric = 1;
-    alg.algProperties.signing = 1;
+    alg.algProperties |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg.algProperties |= TPMA_ALGORITHM_SIGNING;
     alg_ptr = (uint16_t *)(buffer + 10);
     alg_properties_ptr = (uint32_t *)(buffer + sizeof(*alg_ptr) + 10);
 
@@ -113,8 +113,8 @@ tpms_marshal_buffer_null_with_offset(void **state)
     TSS2_RC rc;
 
     alg.alg = TPM2_ALG_ECDSA;
-    alg.algProperties.asymmetric = 1;
-    alg.algProperties.signing = 1;
+    alg.algProperties |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg.algProperties |= TPMA_ALGORITHM_SIGNING;
 
     rc = Tss2_MU_TPMS_ALG_PROPERTY_Marshal(&alg, NULL, sizeof(alg), &offset);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
@@ -162,8 +162,8 @@ tpms_marshal_buffer_size_lt_data_nad_lt_offset(void **state)
     TSS2_RC rc;
 
     alg.alg = TPM2_ALG_ECDSA;
-    alg.algProperties.asymmetric = 1;
-    alg.algProperties.signing = 1;
+    alg.algProperties |= TPMA_ALGORITHM_ASYMMETRIC;
+    alg.algProperties |= TPMA_ALGORITHM_SIGNING;
     rc = Tss2_MU_TPMS_ALG_PROPERTY_Marshal(&alg, buffer, buffer_size, &offset);
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, 10);
@@ -207,7 +207,7 @@ tpms_unmarshal_success(void **state)
     rc = Tss2_MU_TPMS_ALG_PROPERTY_Unmarshal(buffer, buffer_size, &offset, &alg);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (alg.alg, alg_expected);
-    assert_int_equal (alg.algProperties.val, algprop_expected);
+    assert_int_equal (alg.algProperties, algprop_expected);
 
     ptr2 = (TPMS_CAPABILITY_DATA *)(buffer + sizeof(alg));
     ptr2->capability = HOST_TO_BE_32(TPM2_CAP_ECC_CURVES);
@@ -319,7 +319,7 @@ tpms_unmarshal_buffer_size_lt_data_nad_lt_offset(void **state)
 
     ptr = (TPMS_ALG_PROPERTY *) buffer;
     ptr->alg = HOST_TO_BE_16(TPM2_ALG_ECDSA);
-    ptr->algProperties.val = HOST_TO_BE_32(TPMA_ALGORITHM_ASYMMETRIC | TPMA_ALGORITHM_SIGNING);
+    ptr->algProperties = HOST_TO_BE_32(TPMA_ALGORITHM_ASYMMETRIC | TPMA_ALGORITHM_SIGNING);
     rc = Tss2_MU_TPMS_ALG_PROPERTY_Unmarshal(buffer, sizeof(alg), &offset, &alg);
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, 3);


### PR DESCRIPTION
Per spec this changes TPMAs to be used as flags with defines instead of bitfields throughout the project.
For the moment, applications can -DTPM_BITFIELD_LE to use the old behavior.
TODO: Once they are updated the bitfield structs need to be removed from the headers.

Note: This PR is actually just one patch. It is based off of #626 