### PR TITLE
remove double struct definition of TSS2_SYS_CONTEXT

### DIFF
--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -130,8 +130,6 @@ typedef struct {
                             // parsing sessions following handles section.
 } COMMAND_HANDLES;
 
-struct TSS2_SYS_CONTEXT;
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
remove double struct definition of TSS2_SYS_CONTEXT