### PR TITLE
sysapi: fix GetRpBuffer

### DIFF
--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -68,8 +68,6 @@ typedef struct {
     UINT32 cpBufferUsedSize;
     UINT8 *cpBuffer;
     UINT32 *rspParamsSize;  // Points to response paramsSize.
-    UINT32 rpBufferUsedSize;
-    UINT8 *rpBuffer;
     UINT8 previousStage;            // Used to check for sequencing errors.
     UINT8 authsCount;
     UINT8 numResponseHandles;

--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -41,7 +41,6 @@ void InitSysContextFields(_TSS2_SYS_CONTEXT_BLOB *ctx)
     ctx->prepareCalledFromOneCall = 0;
     ctx->completeCalledFromOneCall = 0;
     ctx->nextData = 0;
-    ctx->rpBufferUsedSize = 0;
     ctx->rval = TSS2_RC_SUCCESS;
 }
 
@@ -154,20 +153,15 @@ TSS2_RC CommonComplete(_TSS2_SYS_CONTEXT_BLOB *ctx)
     if (rval)
         return rval;
 
-    /* Save response params size */
+    /* Skiping over response params size field */
     if (tag == TPM2_ST_SESSIONS) {
         rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
                                         ctx->maxCmdSize,
                                         &ctx->nextData,
-                                        &ctx->rpBufferUsedSize);
+                                        NULL);
         if (rval)
             return rval;
     }
-
-    ctx->rpBuffer = ctx->cmdBuffer + ctx->nextData;
-
-    if (tag != TPM2_ST_SESSIONS)
-        ctx->rpBufferUsedSize = rspSize - (ctx->rpBuffer - ctx->cmdBuffer);
 
     return rval;
 }


### PR DESCRIPTION
GetRpBuffer would return garbage if called before
complete. This patch fixes this.
Also eliminates the field rpBuffer from SYS_CONTEXT along
the way.

Signed-off-by: Andreas Fuchs <andreas.fuchs@sit.fraunhofer.de>
Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>