### PR TITLE
sysapi: Update SetCmdAuths and GetRspAuths to new parameter type

### DIFF
--- a/include/sapi/sys_api_part3.h
+++ b/include/sapi/sys_api_part3.h
@@ -430,9 +430,9 @@ TSS2_RC Tss2_Sys_Shutdown_Prepare(
 
 TSS2_RC Tss2_Sys_Shutdown(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2_SU	shutdownType,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_SelfTest_Prepare(
@@ -442,9 +442,9 @@ TSS2_RC Tss2_Sys_SelfTest_Prepare(
 
 TSS2_RC Tss2_Sys_SelfTest(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_YES_NO	fullTest,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_IncrementalSelfTest_Prepare(
@@ -459,10 +459,10 @@ TSS2_RC Tss2_Sys_IncrementalSelfTest_Complete(
 
 TSS2_RC Tss2_Sys_IncrementalSelfTest(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPML_ALG	*toTest,
     TPML_ALG	*toDoList,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_GetTestResult_Prepare(
@@ -477,10 +477,10 @@ TSS2_RC Tss2_Sys_GetTestResult_Complete(
 
 TSS2_RC Tss2_Sys_GetTestResult(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_MAX_BUFFER	*outData,
     TPM2_RC	*testResult,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_StartAuthSession_Prepare(
@@ -504,7 +504,7 @@ TSS2_RC Tss2_Sys_StartAuthSession(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	tpmKey,
     TPMI_DH_ENTITY	bind,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_NONCE	*nonceCaller,
     const TPM2B_ENCRYPTED_SECRET	*encryptedSalt,
     TPM2_SE	sessionType,
@@ -512,7 +512,7 @@ TSS2_RC Tss2_Sys_StartAuthSession(
     TPMI_ALG_HASH	authHash,
     TPMI_SH_AUTH_SESSION	*sessionHandle,
     TPM2B_NONCE	*nonceTPM,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyRestart_Prepare(
@@ -523,8 +523,8 @@ TSS2_RC Tss2_Sys_PolicyRestart_Prepare(
 TSS2_RC Tss2_Sys_PolicyRestart(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	sessionHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Create_Prepare(
@@ -548,7 +548,7 @@ TSS2_RC Tss2_Sys_Create_Complete(
 TSS2_RC Tss2_Sys_Create(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	parentHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_SENSITIVE_CREATE	*inSensitive,
     const TPM2B_PUBLIC	*inPublic,
     const TPM2B_DATA	*outsideInfo,
@@ -558,7 +558,7 @@ TSS2_RC Tss2_Sys_Create(
     TPM2B_CREATION_DATA	*creationData,
     TPM2B_DIGEST	*creationHash,
     TPMT_TK_CREATION	*creationTicket,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Load_Prepare(
@@ -577,12 +577,12 @@ TSS2_RC Tss2_Sys_Load_Complete(
 TSS2_RC Tss2_Sys_Load(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	parentHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_PRIVATE	*inPrivate,
     const TPM2B_PUBLIC	*inPublic,
     TPM2_HANDLE	*objectHandle,
     TPM2B_NAME	*name,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_LoadExternal_Prepare(
@@ -600,13 +600,13 @@ TSS2_RC Tss2_Sys_LoadExternal_Complete(
 
 TSS2_RC Tss2_Sys_LoadExternal(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_SENSITIVE	*inPrivate,
     const TPM2B_PUBLIC	*inPublic,
     TPMI_RH_HIERARCHY	hierarchy,
     TPM2_HANDLE	*objectHandle,
     TPM2B_NAME	*name,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ReadPublic_Prepare(
@@ -624,11 +624,11 @@ TSS2_RC Tss2_Sys_ReadPublic_Complete(
 TSS2_RC Tss2_Sys_ReadPublic(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	objectHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_PUBLIC	*outPublic,
     TPM2B_NAME	*name,
     TPM2B_NAME	*qualifiedName,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ActivateCredential_Prepare(
@@ -648,11 +648,11 @@ TSS2_RC Tss2_Sys_ActivateCredential(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	activateHandle,
     TPMI_DH_OBJECT	keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_ID_OBJECT	*credentialBlob,
     const TPM2B_ENCRYPTED_SECRET	*secret,
     TPM2B_DIGEST	*certInfo,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_MakeCredential_Prepare(
@@ -671,12 +671,12 @@ TSS2_RC Tss2_Sys_MakeCredential_Complete(
 TSS2_RC Tss2_Sys_MakeCredential(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	handle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST	*credential,
     const TPM2B_NAME	*objectName,
     TPM2B_ID_OBJECT	*credentialBlob,
     TPM2B_ENCRYPTED_SECRET	*secret,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Unseal_Prepare(
@@ -692,9 +692,9 @@ TSS2_RC Tss2_Sys_Unseal_Complete(
 TSS2_RC Tss2_Sys_Unseal(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	itemHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_SENSITIVE_DATA	*outData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ObjectChangeAuth_Prepare(
@@ -713,10 +713,10 @@ TSS2_RC Tss2_Sys_ObjectChangeAuth(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	objectHandle,
     TPMI_DH_OBJECT	parentHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH	*newAuth,
     TPM2B_PRIVATE	*outPrivate,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Duplicate_Prepare(
@@ -738,13 +738,13 @@ TSS2_RC Tss2_Sys_Duplicate(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	objectHandle,
     TPMI_DH_OBJECT	newParentHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA	*encryptionKeyIn,
     const TPMT_SYM_DEF_OBJECT	*symmetricAlg,
     TPM2B_DATA	*encryptionKeyOut,
     TPM2B_PRIVATE	*duplicate,
     TPM2B_ENCRYPTED_SECRET	*outSymSeed,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Rewrap_Prepare(
@@ -766,13 +766,13 @@ TSS2_RC Tss2_Sys_Rewrap(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	oldParent,
     TPMI_DH_OBJECT	newParent,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_PRIVATE	*inDuplicate,
     const TPM2B_NAME	*name,
     const TPM2B_ENCRYPTED_SECRET	*inSymSeed,
     TPM2B_PRIVATE	*outDuplicate,
     TPM2B_ENCRYPTED_SECRET	*outSymSeed,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Import_Prepare(
@@ -793,14 +793,14 @@ TSS2_RC Tss2_Sys_Import_Complete(
 TSS2_RC Tss2_Sys_Import(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	parentHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA	*encryptionKey,
     const TPM2B_PUBLIC	*objectPublic,
     const TPM2B_PRIVATE	*duplicate,
     const TPM2B_ENCRYPTED_SECRET	*inSymSeed,
     const TPMT_SYM_DEF_OBJECT	*symmetricAlg,
     TPM2B_PRIVATE	*outPrivate,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_RSA_Encrypt_Prepare(
@@ -819,12 +819,12 @@ TSS2_RC Tss2_Sys_RSA_Encrypt_Complete(
 TSS2_RC Tss2_Sys_RSA_Encrypt(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_PUBLIC_KEY_RSA	*message,
     const TPMT_RSA_DECRYPT	*inScheme,
     const TPM2B_DATA	*label,
     TPM2B_PUBLIC_KEY_RSA	*outData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_RSA_Decrypt_Prepare(
@@ -843,12 +843,12 @@ TSS2_RC Tss2_Sys_RSA_Decrypt_Complete(
 TSS2_RC Tss2_Sys_RSA_Decrypt(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_PUBLIC_KEY_RSA	*cipherText,
     const TPMT_RSA_DECRYPT	*inScheme,
     const TPM2B_DATA	*label,
     TPM2B_PUBLIC_KEY_RSA	*message,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ECDH_KeyGen_Prepare(
@@ -865,10 +865,10 @@ TSS2_RC Tss2_Sys_ECDH_KeyGen_Complete(
 TSS2_RC Tss2_Sys_ECDH_KeyGen(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_ECC_POINT	*zPoint,
     TPM2B_ECC_POINT	*pubPoint,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ECDH_ZGen_Prepare(
@@ -885,10 +885,10 @@ TSS2_RC Tss2_Sys_ECDH_ZGen_Complete(
 TSS2_RC Tss2_Sys_ECDH_ZGen(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_ECC_POINT	*inPoint,
     TPM2B_ECC_POINT	*outPoint,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ECC_Parameters_Prepare(
@@ -903,10 +903,10 @@ TSS2_RC Tss2_Sys_ECC_Parameters_Complete(
 
 TSS2_RC Tss2_Sys_ECC_Parameters(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_ECC_CURVE	curveID,
     TPMS_ALGORITHM_DETAIL_ECC	*parameters,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ZGen_2Phase_Prepare(
@@ -927,14 +927,14 @@ TSS2_RC Tss2_Sys_ZGen_2Phase_Complete(
 TSS2_RC Tss2_Sys_ZGen_2Phase(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	keyA,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_ECC_POINT	*inQsB,
     const TPM2B_ECC_POINT	*inQeB,
     TPMI_ECC_KEY_EXCHANGE	inScheme,
     UINT16	counter,
     TPM2B_ECC_POINT	*outZ1,
     TPM2B_ECC_POINT	*outZ2,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_EncryptDecrypt_Prepare(
@@ -955,14 +955,14 @@ TSS2_RC Tss2_Sys_EncryptDecrypt_Complete(
 TSS2_RC Tss2_Sys_EncryptDecrypt(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_YES_NO	decrypt,
     TPMI_ALG_SYM_MODE	mode,
     const TPM2B_IV	*ivIn,
     const TPM2B_MAX_BUFFER	*inData,
     TPM2B_MAX_BUFFER	*outData,
     TPM2B_IV	*ivOut,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_EncryptDecrypt2_Prepare(
@@ -983,14 +983,14 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2_Complete(
 TSS2_RC Tss2_Sys_EncryptDecrypt2(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER	*inData,
     TPMI_YES_NO	decrypt,
     TPMI_ALG_SYM_MODE	mode,
     const TPM2B_IV	*ivIn,
     TPM2B_MAX_BUFFER	*outData,
     TPM2B_IV	*ivOut,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Hash_Prepare(
@@ -1008,13 +1008,13 @@ TSS2_RC Tss2_Sys_Hash_Complete(
 
 TSS2_RC Tss2_Sys_Hash(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER	*data,
     TPMI_ALG_HASH	hashAlg,
     TPMI_RH_HIERARCHY	hierarchy,
     TPM2B_DIGEST	*outHash,
     TPMT_TK_HASHCHECK	*validation,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_HMAC_Prepare(
@@ -1032,11 +1032,11 @@ TSS2_RC Tss2_Sys_HMAC_Complete(
 TSS2_RC Tss2_Sys_HMAC(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	handle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER	*buffer,
     TPMI_ALG_HASH	hashAlg,
     TPM2B_DIGEST	*outHMAC,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_GetRandom_Prepare(
@@ -1051,10 +1051,10 @@ TSS2_RC Tss2_Sys_GetRandom_Complete(
 
 TSS2_RC Tss2_Sys_GetRandom(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT16	bytesRequested,
     TPM2B_DIGEST	*randomBytes,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_StirRandom_Prepare(
@@ -1064,9 +1064,9 @@ TSS2_RC Tss2_Sys_StirRandom_Prepare(
 
 TSS2_RC Tss2_Sys_StirRandom(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_SENSITIVE_DATA	*inData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_HMAC_Start_Prepare(
@@ -1084,11 +1084,11 @@ TSS2_RC Tss2_Sys_HMAC_Start_Complete(
 TSS2_RC Tss2_Sys_HMAC_Start(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	handle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH	*auth,
     TPMI_ALG_HASH	hashAlg,
     TPMI_DH_OBJECT	*sequenceHandle,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_HashSequenceStart_Prepare(
@@ -1104,11 +1104,11 @@ TSS2_RC Tss2_Sys_HashSequenceStart_Complete(
 
 TSS2_RC Tss2_Sys_HashSequenceStart(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH	*auth,
     TPMI_ALG_HASH	hashAlg,
     TPMI_DH_OBJECT	*sequenceHandle,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_SequenceUpdate_Prepare(
@@ -1120,9 +1120,9 @@ TSS2_RC Tss2_Sys_SequenceUpdate_Prepare(
 TSS2_RC Tss2_Sys_SequenceUpdate(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	sequenceHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER	*buffer,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_SequenceComplete_Prepare(
@@ -1141,12 +1141,12 @@ TSS2_RC Tss2_Sys_SequenceComplete_Complete(
 TSS2_RC Tss2_Sys_SequenceComplete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	sequenceHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER	*buffer,
     TPMI_RH_HIERARCHY	hierarchy,
     TPM2B_DIGEST	*result,
     TPMT_TK_HASHCHECK	*validation,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_EventSequenceComplete_Prepare(
@@ -1165,10 +1165,10 @@ TSS2_RC Tss2_Sys_EventSequenceComplete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR	pcrHandle,
     TPMI_DH_OBJECT	sequenceHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER	*buffer,
     TPML_DIGEST_VALUES	*results,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Certify_Prepare(
@@ -1189,12 +1189,12 @@ TSS2_RC Tss2_Sys_Certify(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	objectHandle,
     TPMI_DH_OBJECT	signHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA	*qualifyingData,
     const TPMT_SIG_SCHEME	*inScheme,
     TPM2B_ATTEST	*certifyInfo,
     TPMT_SIGNATURE	*signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_CertifyCreation_Prepare(
@@ -1217,14 +1217,14 @@ TSS2_RC Tss2_Sys_CertifyCreation(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	signHandle,
     TPMI_DH_OBJECT	objectHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA	*qualifyingData,
     const TPM2B_DIGEST	*creationHash,
     const TPMT_SIG_SCHEME	*inScheme,
     const TPMT_TK_CREATION	*creationTicket,
     TPM2B_ATTEST	*certifyInfo,
     TPMT_SIGNATURE	*signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Quote_Prepare(
@@ -1244,13 +1244,13 @@ TSS2_RC Tss2_Sys_Quote_Complete(
 TSS2_RC Tss2_Sys_Quote(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	signHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA	*qualifyingData,
     const TPMT_SIG_SCHEME	*inScheme,
     const TPML_PCR_SELECTION	*PCRselect,
     TPM2B_ATTEST	*quoted,
     TPMT_SIGNATURE	*signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_GetSessionAuditDigest_Prepare(
@@ -1273,12 +1273,12 @@ TSS2_RC Tss2_Sys_GetSessionAuditDigest(
     TPMI_RH_ENDORSEMENT	privacyAdminHandle,
     TPMI_DH_OBJECT	signHandle,
     TPMI_SH_HMAC	sessionHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA	*qualifyingData,
     const TPMT_SIG_SCHEME	*inScheme,
     TPM2B_ATTEST	*auditInfo,
     TPMT_SIGNATURE	*signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_GetCommandAuditDigest_Prepare(
@@ -1299,12 +1299,12 @@ TSS2_RC Tss2_Sys_GetCommandAuditDigest(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_ENDORSEMENT	privacyHandle,
     TPMI_DH_OBJECT	signHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA	*qualifyingData,
     const TPMT_SIG_SCHEME	*inScheme,
     TPM2B_ATTEST	*auditInfo,
     TPMT_SIGNATURE	*signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_GetTime_Prepare(
@@ -1325,12 +1325,12 @@ TSS2_RC Tss2_Sys_GetTime(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_ENDORSEMENT	privacyAdminHandle,
     TPMI_DH_OBJECT	signHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA	*qualifyingData,
     const TPMT_SIG_SCHEME	*inScheme,
     TPM2B_ATTEST	*timeInfo,
     TPMT_SIGNATURE	*signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Commit_Prepare(
@@ -1352,7 +1352,7 @@ TSS2_RC Tss2_Sys_Commit_Complete(
 TSS2_RC Tss2_Sys_Commit(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	signHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_ECC_POINT	*P1,
     const TPM2B_SENSITIVE_DATA	*s2,
     const TPM2B_ECC_PARAMETER	*y2,
@@ -1360,7 +1360,7 @@ TSS2_RC Tss2_Sys_Commit(
     TPM2B_ECC_POINT	*L,
     TPM2B_ECC_POINT	*E,
     UINT16	*counter,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_EC_Ephemeral_Prepare(
@@ -1376,11 +1376,11 @@ TSS2_RC Tss2_Sys_EC_Ephemeral_Complete(
 
 TSS2_RC Tss2_Sys_EC_Ephemeral(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_ECC_CURVE	curveID,
     TPM2B_ECC_POINT	*Q,
     UINT16	*counter,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_VerifySignature_Prepare(
@@ -1398,11 +1398,11 @@ TSS2_RC Tss2_Sys_VerifySignature_Complete(
 TSS2_RC Tss2_Sys_VerifySignature(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST	*digest,
     const TPMT_SIGNATURE	*signature,
     TPMT_TK_VERIFIED	*validation,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Sign_Prepare(
@@ -1421,12 +1421,12 @@ TSS2_RC Tss2_Sys_Sign_Complete(
 TSS2_RC Tss2_Sys_Sign(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST	*digest,
     const TPMT_SIG_SCHEME	*inScheme,
     const TPMT_TK_HASHCHECK	*validation,
     TPMT_SIGNATURE	*signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus_Prepare(
@@ -1440,11 +1440,11 @@ TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus_Prepare(
 TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION	auth,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_ALG_HASH	auditAlg,
     const TPML_CC	*setList,
     const TPML_CC	*clearList,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PCR_Extend_Prepare(
@@ -1456,9 +1456,9 @@ TSS2_RC Tss2_Sys_PCR_Extend_Prepare(
 TSS2_RC Tss2_Sys_PCR_Extend(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR	pcrHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPML_DIGEST_VALUES	*digests,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PCR_Event_Prepare(
@@ -1475,10 +1475,10 @@ TSS2_RC Tss2_Sys_PCR_Event_Complete(
 TSS2_RC Tss2_Sys_PCR_Event(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR	pcrHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_EVENT	*eventData,
     TPML_DIGEST_VALUES	*digests,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PCR_Read_Prepare(
@@ -1495,12 +1495,12 @@ TSS2_RC Tss2_Sys_PCR_Read_Complete(
 
 TSS2_RC Tss2_Sys_PCR_Read(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPML_PCR_SELECTION	*pcrSelectionIn,
     UINT32	*pcrUpdateCounter,
     TPML_PCR_SELECTION	*pcrSelectionOut,
     TPML_DIGEST	*pcrValues,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PCR_Allocate_Prepare(
@@ -1520,13 +1520,13 @@ TSS2_RC Tss2_Sys_PCR_Allocate_Complete(
 TSS2_RC Tss2_Sys_PCR_Allocate(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPML_PCR_SELECTION	*pcrAllocation,
     TPMI_YES_NO	*allocationSuccess,
     UINT32	*maxPCR,
     UINT32	*sizeNeeded,
     UINT32	*sizeAvailable,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PCR_SetAuthPolicy_Prepare(
@@ -1540,11 +1540,11 @@ TSS2_RC Tss2_Sys_PCR_SetAuthPolicy_Prepare(
 TSS2_RC Tss2_Sys_PCR_SetAuthPolicy(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST	*authPolicy,
     TPMI_ALG_HASH	hashAlg,
     TPMI_DH_PCR	pcrNum,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PCR_SetAuthValue_Prepare(
@@ -1556,9 +1556,9 @@ TSS2_RC Tss2_Sys_PCR_SetAuthValue_Prepare(
 TSS2_RC Tss2_Sys_PCR_SetAuthValue(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR	pcrHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST	*auth,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PCR_Reset_Prepare(
@@ -1569,8 +1569,8 @@ TSS2_RC Tss2_Sys_PCR_Reset_Prepare(
 TSS2_RC Tss2_Sys_PCR_Reset(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR	pcrHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicySigned_Prepare(
@@ -1594,7 +1594,7 @@ TSS2_RC Tss2_Sys_PolicySigned(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT	authObject,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_NONCE	*nonceTPM,
     const TPM2B_DIGEST	*cpHashA,
     const TPM2B_NONCE	*policyRef,
@@ -1602,7 +1602,7 @@ TSS2_RC Tss2_Sys_PolicySigned(
     const TPMT_SIGNATURE	*auth,
     TPM2B_TIMEOUT	*timeout,
     TPMT_TK_AUTH	*policyTicket,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicySecret_Prepare(
@@ -1625,14 +1625,14 @@ TSS2_RC Tss2_Sys_PolicySecret(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_ENTITY	authHandle,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_NONCE	*nonceTPM,
     const TPM2B_DIGEST	*cpHashA,
     const TPM2B_NONCE	*policyRef,
     INT32	expiration,
     TPM2B_TIMEOUT	*timeout,
     TPMT_TK_AUTH	*policyTicket,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyTicket_Prepare(
@@ -1648,13 +1648,13 @@ TSS2_RC Tss2_Sys_PolicyTicket_Prepare(
 TSS2_RC Tss2_Sys_PolicyTicket(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_TIMEOUT	*timeout,
     const TPM2B_DIGEST	*cpHashA,
     const TPM2B_NONCE	*policyRef,
     const TPM2B_NAME	*authName,
     const TPMT_TK_AUTH	*ticket,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyOR_Prepare(
@@ -1666,9 +1666,9 @@ TSS2_RC Tss2_Sys_PolicyOR_Prepare(
 TSS2_RC Tss2_Sys_PolicyOR(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPML_DIGEST	*pHashList,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyPCR_Prepare(
@@ -1681,10 +1681,10 @@ TSS2_RC Tss2_Sys_PolicyPCR_Prepare(
 TSS2_RC Tss2_Sys_PolicyPCR(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST	*pcrDigest,
     const TPML_PCR_SELECTION	*pcrs,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyLocality_Prepare(
@@ -1696,9 +1696,9 @@ TSS2_RC Tss2_Sys_PolicyLocality_Prepare(
 TSS2_RC Tss2_Sys_PolicyLocality(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMA_LOCALITY	locality,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyNV_Prepare(
@@ -1716,11 +1716,11 @@ TSS2_RC Tss2_Sys_PolicyNV(
     TPMI_RH_NV_AUTH	authHandle,
     TPMI_RH_NV_INDEX	nvIndex,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_OPERAND	*operandB,
     UINT16	offset,
     TPM2_EO	operation,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyCounterTimer_Prepare(
@@ -1734,11 +1734,11 @@ TSS2_RC Tss2_Sys_PolicyCounterTimer_Prepare(
 TSS2_RC Tss2_Sys_PolicyCounterTimer(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_OPERAND	*operandB,
     UINT16	offset,
     TPM2_EO	operation,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyCommandCode_Prepare(
@@ -1750,9 +1750,9 @@ TSS2_RC Tss2_Sys_PolicyCommandCode_Prepare(
 TSS2_RC Tss2_Sys_PolicyCommandCode(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2_CC	code,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyPhysicalPresence_Prepare(
@@ -1763,8 +1763,8 @@ TSS2_RC Tss2_Sys_PolicyPhysicalPresence_Prepare(
 TSS2_RC Tss2_Sys_PolicyPhysicalPresence(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyCpHash_Prepare(
@@ -1776,9 +1776,9 @@ TSS2_RC Tss2_Sys_PolicyCpHash_Prepare(
 TSS2_RC Tss2_Sys_PolicyCpHash(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST	*cpHashA,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyNameHash_Prepare(
@@ -1790,9 +1790,9 @@ TSS2_RC Tss2_Sys_PolicyNameHash_Prepare(
 TSS2_RC Tss2_Sys_PolicyNameHash(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST	*nameHash,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyDuplicationSelect_Prepare(
@@ -1806,11 +1806,11 @@ TSS2_RC Tss2_Sys_PolicyDuplicationSelect_Prepare(
 TSS2_RC Tss2_Sys_PolicyDuplicationSelect(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_NAME	*objectName,
     const TPM2B_NAME	*newParentName,
     TPMI_YES_NO	includeObject,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyAuthorize_Prepare(
@@ -1825,12 +1825,12 @@ TSS2_RC Tss2_Sys_PolicyAuthorize_Prepare(
 TSS2_RC Tss2_Sys_PolicyAuthorize(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST	*approvedPolicy,
     const TPM2B_NONCE	*policyRef,
     const TPM2B_NAME	*keySign,
     const TPMT_TK_VERIFIED	*checkTicket,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyAuthValue_Prepare(
@@ -1841,8 +1841,8 @@ TSS2_RC Tss2_Sys_PolicyAuthValue_Prepare(
 TSS2_RC Tss2_Sys_PolicyAuthValue(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyPassword_Prepare(
@@ -1853,8 +1853,8 @@ TSS2_RC Tss2_Sys_PolicyPassword_Prepare(
 TSS2_RC Tss2_Sys_PolicyPassword(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyGetDigest_Prepare(
@@ -1870,9 +1870,9 @@ TSS2_RC Tss2_Sys_PolicyGetDigest_Complete(
 TSS2_RC Tss2_Sys_PolicyGetDigest(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_DIGEST	*policyDigest,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PolicyNvWritten_Prepare(
@@ -1884,9 +1884,9 @@ TSS2_RC Tss2_Sys_PolicyNvWritten_Prepare(
 TSS2_RC Tss2_Sys_PolicyNvWritten(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY	policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_YES_NO	writtenSet,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_CreatePrimary_Prepare(
@@ -1911,7 +1911,7 @@ TSS2_RC Tss2_Sys_CreatePrimary_Complete(
 TSS2_RC Tss2_Sys_CreatePrimary(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY	primaryHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_SENSITIVE_CREATE	*inSensitive,
     const TPM2B_PUBLIC	*inPublic,
     const TPM2B_DATA	*outsideInfo,
@@ -1922,7 +1922,7 @@ TSS2_RC Tss2_Sys_CreatePrimary(
     TPM2B_DIGEST	*creationHash,
     TPMT_TK_CREATION	*creationTicket,
     TPM2B_NAME	*name,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_HierarchyControl_Prepare(
@@ -1935,10 +1935,10 @@ TSS2_RC Tss2_Sys_HierarchyControl_Prepare(
 TSS2_RC Tss2_Sys_HierarchyControl(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_RH_ENABLES	enable,
     TPMI_YES_NO	state,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_SetPrimaryPolicy_Prepare(
@@ -1951,10 +1951,10 @@ TSS2_RC Tss2_Sys_SetPrimaryPolicy_Prepare(
 TSS2_RC Tss2_Sys_SetPrimaryPolicy(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY_AUTH	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST	*authPolicy,
     TPMI_ALG_HASH	hashAlg,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ChangePPS_Prepare(
@@ -1965,8 +1965,8 @@ TSS2_RC Tss2_Sys_ChangePPS_Prepare(
 TSS2_RC Tss2_Sys_ChangePPS(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ChangeEPS_Prepare(
@@ -1977,8 +1977,8 @@ TSS2_RC Tss2_Sys_ChangeEPS_Prepare(
 TSS2_RC Tss2_Sys_ChangeEPS(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Clear_Prepare(
@@ -1989,8 +1989,8 @@ TSS2_RC Tss2_Sys_Clear_Prepare(
 TSS2_RC Tss2_Sys_Clear(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_CLEAR	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ClearControl_Prepare(
@@ -2002,9 +2002,9 @@ TSS2_RC Tss2_Sys_ClearControl_Prepare(
 TSS2_RC Tss2_Sys_ClearControl(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_CLEAR	auth,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_YES_NO	disable,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_HierarchyChangeAuth_Prepare(
@@ -2016,9 +2016,9 @@ TSS2_RC Tss2_Sys_HierarchyChangeAuth_Prepare(
 TSS2_RC Tss2_Sys_HierarchyChangeAuth(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY_AUTH	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH	*newAuth,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_DictionaryAttackLockReset_Prepare(
@@ -2029,8 +2029,8 @@ TSS2_RC Tss2_Sys_DictionaryAttackLockReset_Prepare(
 TSS2_RC Tss2_Sys_DictionaryAttackLockReset(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_LOCKOUT	lockHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_DictionaryAttackParameters_Prepare(
@@ -2044,11 +2044,11 @@ TSS2_RC Tss2_Sys_DictionaryAttackParameters_Prepare(
 TSS2_RC Tss2_Sys_DictionaryAttackParameters(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_LOCKOUT	lockHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT32	newMaxTries,
     UINT32	newRecoveryTime,
     UINT32	lockoutRecovery,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_PP_Commands_Prepare(
@@ -2061,10 +2061,10 @@ TSS2_RC Tss2_Sys_PP_Commands_Prepare(
 TSS2_RC Tss2_Sys_PP_Commands(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM	auth,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPML_CC	*setList,
     const TPML_CC	*clearList,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_SetAlgorithmSet_Prepare(
@@ -2076,9 +2076,9 @@ TSS2_RC Tss2_Sys_SetAlgorithmSet_Prepare(
 TSS2_RC Tss2_Sys_SetAlgorithmSet(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT32	algorithmSet,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_FieldUpgradeStart_Prepare(
@@ -2093,10 +2093,10 @@ TSS2_RC Tss2_Sys_FieldUpgradeStart(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM	authorization,
     TPMI_DH_OBJECT	keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_DIGEST	*fuDigest,
     TPMT_SIGNATURE	*manifestSignature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_FieldUpgradeData_Prepare(
@@ -2112,11 +2112,11 @@ TSS2_RC Tss2_Sys_FieldUpgradeData_Complete(
 
 TSS2_RC Tss2_Sys_FieldUpgradeData(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_MAX_BUFFER	*fuData,
     TPMT_HA	*nextDigest,
     TPMT_HA	*firstDigest,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_FirmwareRead_Prepare(
@@ -2131,10 +2131,10 @@ TSS2_RC Tss2_Sys_FirmwareRead_Complete(
 
 TSS2_RC Tss2_Sys_FirmwareRead(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT32	sequenceNumber,
     TPM2B_MAX_BUFFER	*fuData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ContextSave_Prepare(
@@ -2190,9 +2190,9 @@ TSS2_RC Tss2_Sys_EvictControl(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION	auth,
     TPMI_DH_OBJECT	objectHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_DH_PERSISTENT	persistentHandle,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ReadClock_Prepare(
@@ -2218,9 +2218,9 @@ TSS2_RC Tss2_Sys_ClockSet_Prepare(
 TSS2_RC Tss2_Sys_ClockSet(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION	auth,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT64	newTime,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_ClockRateAdjust_Prepare(
@@ -2232,9 +2232,9 @@ TSS2_RC Tss2_Sys_ClockRateAdjust_Prepare(
 TSS2_RC Tss2_Sys_ClockRateAdjust(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION	auth,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2_CLOCK_ADJUST	rateAdjust,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_GetCapability_Prepare(
@@ -2252,13 +2252,13 @@ TSS2_RC Tss2_Sys_GetCapability_Complete(
 
 TSS2_RC Tss2_Sys_GetCapability(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2_CAP	capability,
     UINT32	property,
     UINT32	propertyCount,
     TPMI_YES_NO	*moreData,
     TPMS_CAPABILITY_DATA	*capabilityData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_TestParms_Prepare(
@@ -2268,9 +2268,9 @@ TSS2_RC Tss2_Sys_TestParms_Prepare(
 
 TSS2_RC Tss2_Sys_TestParms(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPMT_PUBLIC_PARMS	*parameters,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_DefineSpace_Prepare(
@@ -2283,10 +2283,10 @@ TSS2_RC Tss2_Sys_NV_DefineSpace_Prepare(
 TSS2_RC Tss2_Sys_NV_DefineSpace(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH	*auth,
     const TPM2B_NV_PUBLIC	*publicInfo,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_UndefineSpace_Prepare(
@@ -2299,8 +2299,8 @@ TSS2_RC Tss2_Sys_NV_UndefineSpace(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION	authHandle,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_UndefineSpaceSpecial_Prepare(
@@ -2313,8 +2313,8 @@ TSS2_RC Tss2_Sys_NV_UndefineSpaceSpecial(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX	nvIndex,
     TPMI_RH_PLATFORM	platform,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_ReadPublic_Prepare(
@@ -2331,10 +2331,10 @@ TSS2_RC Tss2_Sys_NV_ReadPublic_Complete(
 TSS2_RC Tss2_Sys_NV_ReadPublic(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_NV_PUBLIC	*nvPublic,
     TPM2B_NAME	*nvName,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_Write_Prepare(
@@ -2349,10 +2349,10 @@ TSS2_RC Tss2_Sys_NV_Write(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH	authHandle,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_NV_BUFFER	*data,
     UINT16	offset,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_Increment_Prepare(
@@ -2365,8 +2365,8 @@ TSS2_RC Tss2_Sys_NV_Increment(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH	authHandle,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_Extend_Prepare(
@@ -2380,9 +2380,9 @@ TSS2_RC Tss2_Sys_NV_Extend(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH	authHandle,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_NV_BUFFER	*data,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_SetBits_Prepare(
@@ -2396,9 +2396,9 @@ TSS2_RC Tss2_Sys_NV_SetBits(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH	authHandle,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT64	bits,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_WriteLock_Prepare(
@@ -2411,8 +2411,8 @@ TSS2_RC Tss2_Sys_NV_WriteLock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH	authHandle,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_GlobalWriteLock_Prepare(
@@ -2423,8 +2423,8 @@ TSS2_RC Tss2_Sys_NV_GlobalWriteLock_Prepare(
 TSS2_RC Tss2_Sys_NV_GlobalWriteLock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION	authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_Read_Prepare(
@@ -2444,11 +2444,11 @@ TSS2_RC Tss2_Sys_NV_Read(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH	authHandle,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT16	size,
     UINT16	offset,
     TPM2B_MAX_NV_BUFFER	*data,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_ReadLock_Prepare(
@@ -2461,8 +2461,8 @@ TSS2_RC Tss2_Sys_NV_ReadLock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH	authHandle,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_ChangeAuth_Prepare(
@@ -2474,9 +2474,9 @@ TSS2_RC Tss2_Sys_NV_ChangeAuth_Prepare(
 TSS2_RC Tss2_Sys_NV_ChangeAuth(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH	*newAuth,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_NV_Certify_Prepare(
@@ -2501,14 +2501,14 @@ TSS2_RC Tss2_Sys_NV_Certify(
     TPMI_DH_OBJECT	signHandle,
     TPMI_RH_NV_AUTH	authHandle,
     TPMI_RH_NV_INDEX	nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA	*qualifyingData,
     const TPMT_SIG_SCHEME	*inScheme,
     UINT16	size,
     UINT16	offset,
     TPM2B_ATTEST	*certifyInfo,
     TPMT_SIGNATURE	*signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_Vendor_TCG_Test_Prepare(
@@ -2523,10 +2523,10 @@ TSS2_RC Tss2_Sys_Vendor_TCG_Test_Complete(
 
 TSS2_RC Tss2_Sys_Vendor_TCG_Test(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA	*inputData,
     TPM2B_DATA	*outputData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 #endif

--- a/include/sapi/tss2_sys.h
+++ b/include/sapi/tss2_sys.h
@@ -55,17 +55,14 @@ typedef struct _TSS2_SYS_OPAQUE_CONTEXT_BLOB TSS2_SYS_CONTEXT;
 // Input structure for authorization area(s).
 //
 typedef struct {
-    uint8_t cmdAuthsCount;
-    TPMS_AUTH_COMMAND **cmdAuths;
-} TSS2_SYS_CMD_AUTHS;
+    uint16_t          count;
+    TPMS_AUTH_COMMAND auths[3];
+} TSS2L_SYS_AUTH_COMMAND;
 
-//
-// Output structure for authorization area(s).
-//
 typedef struct {
-    uint8_t rspAuthsCount;
-    TPMS_AUTH_RESPONSE **rspAuths;
-} TSS2_SYS_RSP_AUTHS;
+    uint16_t           count;
+    TPMS_AUTH_RESPONSE auths[3];
+} TSS2L_SYS_AUTH_RESPONSE;
 
 
 //
@@ -123,7 +120,7 @@ TSS2_RC Tss2_Sys_GetCpBuffer(
 
 TSS2_RC Tss2_Sys_SetCmdAuths(
     TSS2_SYS_CONTEXT * sysContext,
-    const TSS2_SYS_CMD_AUTHS *cmdAuthsArray
+    const TSS2L_SYS_AUTH_COMMAND *cmdAuthsArray
     );
 
 
@@ -153,7 +150,7 @@ TSS2_RC Tss2_Sys_GetCommandCode(
 
 TSS2_RC Tss2_Sys_GetRspAuths(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray
     );
 
 TSS2_RC Tss2_Sys_GetEncryptParam(

--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -145,8 +145,8 @@ TSS2_RC CommonComplete(_TSS2_SYS_CONTEXT_BLOB *ctx);
 
 TSS2_RC CommonOneCall(
     _TSS2_SYS_CONTEXT_BLOB *ctx,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray);
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray);
 
 TSS2_RC CommonPreparePrologue(
     _TSS2_SYS_CONTEXT_BLOB *ctx,

--- a/sysapi/sysapi/Tss2_Sys_ActivateCredential.c
+++ b/sysapi/sysapi/Tss2_Sys_ActivateCredential.c
@@ -112,11 +112,11 @@ TSS2_RC Tss2_Sys_ActivateCredential(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT activateHandle,
     TPMI_DH_OBJECT keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_ID_OBJECT *credentialBlob,
     const TPM2B_ENCRYPTED_SECRET *secret,
     TPM2B_DIGEST *certInfo,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     TSS2_RC rval;
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);

--- a/sysapi/sysapi/Tss2_Sys_Certify.c
+++ b/sysapi/sysapi/Tss2_Sys_Certify.c
@@ -117,12 +117,12 @@ TSS2_RC Tss2_Sys_Certify(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT objectHandle,
     TPMI_DH_OBJECT signHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA *qualifyingData,
     const TPMT_SIG_SCHEME *inScheme,
     TPM2B_ATTEST *certifyInfo,
     TPMT_SIGNATURE *signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     TSS2_RC rval;
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);

--- a/sysapi/sysapi/Tss2_Sys_CertifyCreation.c
+++ b/sysapi/sysapi/Tss2_Sys_CertifyCreation.c
@@ -132,14 +132,14 @@ TSS2_RC Tss2_Sys_CertifyCreation(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT signHandle,
     TPMI_DH_OBJECT objectHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA *qualifyingData,
     const TPM2B_DIGEST *creationHash,
     const TPMT_SIG_SCHEME *inScheme,
     const TPMT_TK_CREATION *creationTicket,
     TPM2B_ATTEST *certifyInfo,
     TPMT_SIGNATURE *signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ChangeEPS.c
+++ b/sysapi/sysapi/Tss2_Sys_ChangeEPS.c
@@ -69,8 +69,8 @@ TSS2_RC Tss2_Sys_ChangeEPS_Complete (
 TSS2_RC Tss2_Sys_ChangeEPS(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ChangePPS.c
+++ b/sysapi/sysapi/Tss2_Sys_ChangePPS.c
@@ -69,8 +69,8 @@ TSS2_RC Tss2_Sys_ChangePPS_Complete (
 TSS2_RC Tss2_Sys_ChangePPS(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Clear.c
+++ b/sysapi/sysapi/Tss2_Sys_Clear.c
@@ -69,8 +69,8 @@ TSS2_RC Tss2_Sys_Clear_Complete (
 TSS2_RC Tss2_Sys_Clear(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_CLEAR authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ClearControl.c
+++ b/sysapi/sysapi/Tss2_Sys_ClearControl.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_ClearControl_Complete (
 TSS2_RC Tss2_Sys_ClearControl(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_CLEAR auth,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_YES_NO disable,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ClockRateAdjust.c
+++ b/sysapi/sysapi/Tss2_Sys_ClockRateAdjust.c
@@ -75,9 +75,9 @@ TSS2_RC Tss2_Sys_ClockRateAdjust_Complete (
 TSS2_RC Tss2_Sys_ClockRateAdjust(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION auth,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2_CLOCK_ADJUST rateAdjust,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ClockSet.c
+++ b/sysapi/sysapi/Tss2_Sys_ClockSet.c
@@ -75,9 +75,9 @@ TSS2_RC Tss2_Sys_ClockSet_Complete (
 TSS2_RC Tss2_Sys_ClockSet(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION auth,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT64 newTime,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Commit.c
+++ b/sysapi/sysapi/Tss2_Sys_Commit.c
@@ -128,7 +128,7 @@ TSS2_RC Tss2_Sys_Commit_Complete(
 TSS2_RC Tss2_Sys_Commit(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT signHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_ECC_POINT *P1,
     const TPM2B_SENSITIVE_DATA *s2,
     const TPM2B_ECC_PARAMETER *y2,
@@ -136,7 +136,7 @@ TSS2_RC Tss2_Sys_Commit(
     TPM2B_ECC_POINT *L,
     TPM2B_ECC_POINT *E,
     UINT16 *counter,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Create.c
+++ b/sysapi/sysapi/Tss2_Sys_Create.c
@@ -150,7 +150,7 @@ TSS2_RC Tss2_Sys_Create_Complete(
 TSS2_RC Tss2_Sys_Create(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT parentHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_SENSITIVE_CREATE *inSensitive,
     const TPM2B_PUBLIC *inPublic,
     const TPM2B_DATA *outsideInfo,
@@ -160,7 +160,7 @@ TSS2_RC Tss2_Sys_Create(
     TPM2B_CREATION_DATA *creationData,
     TPM2B_DIGEST *creationHash,
     TPMT_TK_CREATION *creationTicket,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_CreatePrimary.c
+++ b/sysapi/sysapi/Tss2_Sys_CreatePrimary.c
@@ -159,7 +159,7 @@ TSS2_RC Tss2_Sys_CreatePrimary_Complete(
 TSS2_RC Tss2_Sys_CreatePrimary(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY primaryHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_SENSITIVE_CREATE *inSensitive,
     const TPM2B_PUBLIC *inPublic,
     const TPM2B_DATA *outsideInfo,
@@ -170,7 +170,7 @@ TSS2_RC Tss2_Sys_CreatePrimary(
     TPM2B_DIGEST *creationHash,
     TPMT_TK_CREATION *creationTicket,
     TPM2B_NAME *name,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_DictionaryAttackLockReset.c
+++ b/sysapi/sysapi/Tss2_Sys_DictionaryAttackLockReset.c
@@ -69,8 +69,8 @@ TSS2_RC Tss2_Sys_DictionaryAttackLockReset_Complete (
 TSS2_RC Tss2_Sys_DictionaryAttackLockReset(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_LOCKOUT lockHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_DictionaryAttackParameters.c
+++ b/sysapi/sysapi/Tss2_Sys_DictionaryAttackParameters.c
@@ -89,11 +89,11 @@ TSS2_RC Tss2_Sys_DictionaryAttackParameters_Complete (
 TSS2_RC Tss2_Sys_DictionaryAttackParameters(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_LOCKOUT lockHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT32 newMaxTries,
     UINT32 newRecoveryTime,
     UINT32 lockoutRecovery,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Duplicate.c
+++ b/sysapi/sysapi/Tss2_Sys_Duplicate.c
@@ -127,13 +127,13 @@ TSS2_RC Tss2_Sys_Duplicate(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT objectHandle,
     TPMI_DH_OBJECT newParentHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA *encryptionKeyIn,
     const TPMT_SYM_DEF_OBJECT *symmetricAlg,
     TPM2B_DATA *encryptionKeyOut,
     TPM2B_PRIVATE *duplicate,
     TPM2B_ENCRYPTED_SECRET *outSymSeed,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ECC_Parameters.c
+++ b/sysapi/sysapi/Tss2_Sys_ECC_Parameters.c
@@ -77,10 +77,10 @@ TSS2_RC Tss2_Sys_ECC_Parameters_Complete(
 
 TSS2_RC Tss2_Sys_ECC_Parameters(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_ECC_CURVE curveID,
     TPMS_ALGORITHM_DETAIL_ECC *parameters,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ECDH_KeyGen.c
+++ b/sysapi/sysapi/Tss2_Sys_ECDH_KeyGen.c
@@ -86,10 +86,10 @@ TSS2_RC Tss2_Sys_ECDH_KeyGen_Complete(
 TSS2_RC Tss2_Sys_ECDH_KeyGen(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_ECC_POINT *zPoint,
     TPM2B_ECC_POINT *pubPoint,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ECDH_ZGen.c
+++ b/sysapi/sysapi/Tss2_Sys_ECDH_ZGen.c
@@ -85,10 +85,10 @@ TSS2_RC Tss2_Sys_ECDH_ZGen_Complete(
 TSS2_RC Tss2_Sys_ECDH_ZGen(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_ECC_POINT *inPoint,
     TPM2B_ECC_POINT *outPoint,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_EC_Ephemeral.c
+++ b/sysapi/sysapi/Tss2_Sys_EC_Ephemeral.c
@@ -82,11 +82,11 @@ TSS2_RC Tss2_Sys_EC_Ephemeral_Complete(
 
 TSS2_RC Tss2_Sys_EC_Ephemeral(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_ECC_CURVE curveID,
     TPM2B_ECC_POINT *Q,
     UINT16 *counter,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_EncryptDecrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_EncryptDecrypt.c
@@ -114,14 +114,14 @@ TSS2_RC Tss2_Sys_EncryptDecrypt_Complete(
 TSS2_RC Tss2_Sys_EncryptDecrypt(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_YES_NO decrypt,
     TPMI_ALG_SYM_MODE mode,
     const TPM2B_IV *ivIn,
     const TPM2B_MAX_BUFFER *inData,
     TPM2B_MAX_BUFFER *outData,
     TPM2B_IV *ivOut,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_EncryptDecrypt2.c
+++ b/sysapi/sysapi/Tss2_Sys_EncryptDecrypt2.c
@@ -119,14 +119,14 @@ TSS2_RC Tss2_Sys_EncryptDecrypt2_Complete (
 TSS2_RC Tss2_Sys_EncryptDecrypt2 (
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER *inData,
     TPMI_YES_NO decrypt,
     TPMI_ALG_SYM_MODE mode,
     const TPM2B_IV *ivIn,
     TPM2B_MAX_BUFFER *outData,
     TPM2B_IV *ivOut,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_EventSequenceComplete.c
+++ b/sysapi/sysapi/Tss2_Sys_EventSequenceComplete.c
@@ -92,10 +92,10 @@ TSS2_RC Tss2_Sys_EventSequenceComplete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
     TPMI_DH_OBJECT sequenceHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER *buffer,
     TPML_DIGEST_VALUES *results,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_EvictControl.c
+++ b/sysapi/sysapi/Tss2_Sys_EvictControl.c
@@ -82,9 +82,9 @@ TSS2_RC Tss2_Sys_EvictControl(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION auth,
     TPMI_DH_OBJECT objectHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_DH_PERSISTENT persistentHandle,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_FieldUpgradeData.c
+++ b/sysapi/sysapi/Tss2_Sys_FieldUpgradeData.c
@@ -86,11 +86,11 @@ TSS2_RC Tss2_Sys_FieldUpgradeData_Complete(
 
 TSS2_RC Tss2_Sys_FieldUpgradeData(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_MAX_BUFFER *fuData,
     TPMT_HA *nextDigest,
     TPMT_HA *firstDigest,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_FieldUpgradeStart.c
+++ b/sysapi/sysapi/Tss2_Sys_FieldUpgradeStart.c
@@ -101,10 +101,10 @@ TSS2_RC Tss2_Sys_FieldUpgradeStart(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authorization,
     TPMI_DH_OBJECT keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_DIGEST *fuDigest,
     TPMT_SIGNATURE *manifestSignature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_FirmwareRead.c
+++ b/sysapi/sysapi/Tss2_Sys_FirmwareRead.c
@@ -76,10 +76,10 @@ TSS2_RC Tss2_Sys_FirmwareRead_Complete(
 
 TSS2_RC Tss2_Sys_FirmwareRead(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT32 sequenceNumber,
     TPM2B_MAX_BUFFER *fuData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_GetCapability.c
+++ b/sysapi/sysapi/Tss2_Sys_GetCapability.c
@@ -99,13 +99,13 @@ TSS2_RC Tss2_Sys_GetCapability_Complete(
 
 TSS2_RC Tss2_Sys_GetCapability(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2_CAP capability,
     UINT32 property,
     UINT32 propertyCount,
     TPMI_YES_NO *moreData,
     TPMS_CAPABILITY_DATA *capabilityData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_GetCommandAuditDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_GetCommandAuditDigest.c
@@ -116,12 +116,12 @@ TSS2_RC Tss2_Sys_GetCommandAuditDigest(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_ENDORSEMENT privacyHandle,
     TPMI_DH_OBJECT signHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA *qualifyingData,
     const TPMT_SIG_SCHEME *inScheme,
     TPM2B_ATTEST *auditInfo,
     TPMT_SIGNATURE *signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_GetRandom.c
+++ b/sysapi/sysapi/Tss2_Sys_GetRandom.c
@@ -75,10 +75,10 @@ TSS2_RC Tss2_Sys_GetRandom_Complete(
 
 TSS2_RC Tss2_Sys_GetRandom(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT16 bytesRequested,
     TPM2B_DIGEST *randomBytes,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_GetSessionAuditDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_GetSessionAuditDigest.c
@@ -124,12 +124,12 @@ TSS2_RC Tss2_Sys_GetSessionAuditDigest(
     TPMI_RH_ENDORSEMENT privacyAdminHandle,
     TPMI_DH_OBJECT signHandle,
     TPMI_SH_HMAC sessionHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA *qualifyingData,
     const TPMT_SIG_SCHEME *inScheme,
     TPM2B_ATTEST *auditInfo,
     TPMT_SIGNATURE *signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_GetTestResult.c
+++ b/sysapi/sysapi/Tss2_Sys_GetTestResult.c
@@ -78,10 +78,10 @@ TSS2_RC Tss2_Sys_GetTestResult_Complete(
 
 TSS2_RC Tss2_Sys_GetTestResult(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_MAX_BUFFER *outData,
     TSS2_RC *testResult,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_GetTime.c
+++ b/sysapi/sysapi/Tss2_Sys_GetTime.c
@@ -117,12 +117,12 @@ TSS2_RC Tss2_Sys_GetTime(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_ENDORSEMENT privacyAdminHandle,
     TPMI_DH_OBJECT signHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA *qualifyingData,
     const TPMT_SIG_SCHEME *inScheme,
     TPM2B_ATTEST *timeInfo,
     TPMT_SIGNATURE *signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_HMAC.c
+++ b/sysapi/sysapi/Tss2_Sys_HMAC.c
@@ -102,11 +102,11 @@ TSS2_RC Tss2_Sys_HMAC_Complete(
 TSS2_RC Tss2_Sys_HMAC(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT handle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER *buffer,
     TPMI_ALG_HASH hashAlg,
     TPM2B_DIGEST *outHMAC,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_HMAC_Start.c
+++ b/sysapi/sysapi/Tss2_Sys_HMAC_Start.c
@@ -103,11 +103,11 @@ TSS2_RC Tss2_Sys_HMAC_Start_Complete(
 TSS2_RC Tss2_Sys_HMAC_Start(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT handle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH *auth,
     TPMI_ALG_HASH hashAlg,
     TPMI_DH_OBJECT *sequenceHandle,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Hash.c
+++ b/sysapi/sysapi/Tss2_Sys_Hash.c
@@ -109,13 +109,13 @@ TSS2_RC Tss2_Sys_Hash_Complete(
 
 TSS2_RC Tss2_Sys_Hash(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER *data,
     TPMI_ALG_HASH hashAlg,
     TPMI_RH_HIERARCHY hierarchy,
     TPM2B_DIGEST *outHash,
     TPMT_TK_HASHCHECK *validation,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_HashSequenceStart.c
+++ b/sysapi/sysapi/Tss2_Sys_HashSequenceStart.c
@@ -94,11 +94,11 @@ TSS2_RC Tss2_Sys_HashSequenceStart_Complete(
 
 TSS2_RC Tss2_Sys_HashSequenceStart(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH *auth,
     TPMI_ALG_HASH hashAlg,
     TPMI_DH_OBJECT *sequenceHandle,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_HierarchyChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_HierarchyChangeAuth.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_HierarchyChangeAuth_Complete (
 TSS2_RC Tss2_Sys_HierarchyChangeAuth(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY_AUTH authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH *newAuth,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_HierarchyControl.c
+++ b/sysapi/sysapi/Tss2_Sys_HierarchyControl.c
@@ -83,10 +83,10 @@ TSS2_RC Tss2_Sys_HierarchyControl_Complete (
 TSS2_RC Tss2_Sys_HierarchyControl(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_RH_ENABLES enable,
     TPMI_YES_NO state,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Import.c
+++ b/sysapi/sysapi/Tss2_Sys_Import.c
@@ -125,14 +125,14 @@ TSS2_RC Tss2_Sys_Import_Complete(
 TSS2_RC Tss2_Sys_Import(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT parentHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA *encryptionKey,
     const TPM2B_PUBLIC *objectPublic,
     const TPM2B_PRIVATE *duplicate,
     const TPM2B_ENCRYPTED_SECRET *inSymSeed,
     const TPMT_SYM_DEF_OBJECT *symmetricAlg,
     TPM2B_PRIVATE *outPrivate,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_IncrementalSelfTest.c
+++ b/sysapi/sysapi/Tss2_Sys_IncrementalSelfTest.c
@@ -76,10 +76,10 @@ TSS2_RC Tss2_Sys_IncrementalSelfTest_Complete(
 
 TSS2_RC Tss2_Sys_IncrementalSelfTest(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPML_ALG *toTest,
     TPML_ALG *toDoList,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Load.c
+++ b/sysapi/sysapi/Tss2_Sys_Load.c
@@ -108,12 +108,12 @@ TSS2_RC Tss2_Sys_Load_Complete(
 TSS2_RC Tss2_Sys_Load(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT parentHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_PRIVATE *inPrivate,
     const TPM2B_PUBLIC *inPublic,
     TPM2_HANDLE *objectHandle,
     TPM2B_NAME *name,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_LoadExternal.c
+++ b/sysapi/sysapi/Tss2_Sys_LoadExternal.c
@@ -108,13 +108,13 @@ TSS2_RC Tss2_Sys_LoadExternal_Complete(
 
 TSS2_RC Tss2_Sys_LoadExternal(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_SENSITIVE *inPrivate,
     const TPM2B_PUBLIC *inPublic,
     TPMI_RH_HIERARCHY hierarchy,
     TPM2_HANDLE *objectHandle,
     TPM2B_NAME *name,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_MakeCredential.c
+++ b/sysapi/sysapi/Tss2_Sys_MakeCredential.c
@@ -110,12 +110,12 @@ TSS2_RC Tss2_Sys_MakeCredential_Complete(
 TSS2_RC Tss2_Sys_MakeCredential(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT handle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST *credential,
     const TPM2B_NAME *objectName,
     TPM2B_ID_OBJECT *credentialBlob,
     TPM2B_ENCRYPTED_SECRET *secret,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_Certify.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Certify.c
@@ -140,14 +140,14 @@ TSS2_RC Tss2_Sys_NV_Certify(
     TPMI_DH_OBJECT signHandle,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA *qualifyingData,
     const TPMT_SIG_SCHEME *inScheme,
     UINT16 size,
     UINT16 offset,
     TPM2B_ATTEST *certifyInfo,
     TPMT_SIGNATURE *signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_ChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ChangeAuth.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_NV_ChangeAuth_Complete (
 TSS2_RC Tss2_Sys_NV_ChangeAuth(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH *newAuth,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_DefineSpace.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_DefineSpace.c
@@ -93,10 +93,10 @@ TSS2_RC Tss2_Sys_NV_DefineSpace_Complete (
 TSS2_RC Tss2_Sys_NV_DefineSpace(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH *auth,
     const TPM2B_NV_PUBLIC *publicInfo,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_Extend.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Extend.c
@@ -84,9 +84,9 @@ TSS2_RC Tss2_Sys_NV_Extend(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_NV_BUFFER *data,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_GlobalWriteLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_GlobalWriteLock.c
@@ -69,8 +69,8 @@ TSS2_RC Tss2_Sys_NV_GlobalWriteLock_Complete (
 TSS2_RC Tss2_Sys_NV_GlobalWriteLock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_Increment.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Increment.c
@@ -77,8 +77,8 @@ TSS2_RC Tss2_Sys_NV_Increment(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_Read.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Read.c
@@ -100,11 +100,11 @@ TSS2_RC Tss2_Sys_NV_Read(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT16 size,
     UINT16 offset,
     TPM2B_MAX_NV_BUFFER *data,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_ReadLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ReadLock.c
@@ -77,8 +77,8 @@ TSS2_RC Tss2_Sys_NV_ReadLock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_ReadPublic.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ReadPublic.c
@@ -86,10 +86,10 @@ TSS2_RC Tss2_Sys_NV_ReadPublic_Complete(
 TSS2_RC Tss2_Sys_NV_ReadPublic(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_NV_PUBLIC *nvPublic,
     TPM2B_NAME *nvName,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_SetBits.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_SetBits.c
@@ -84,9 +84,9 @@ TSS2_RC Tss2_Sys_NV_SetBits(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT64 bits,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_UndefineSpace.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_UndefineSpace.c
@@ -77,8 +77,8 @@ TSS2_RC Tss2_Sys_NV_UndefineSpace(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_UndefineSpaceSpecial.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_UndefineSpaceSpecial.c
@@ -77,8 +77,8 @@ TSS2_RC Tss2_Sys_NV_UndefineSpaceSpecial(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_INDEX nvIndex,
     TPMI_RH_PLATFORM platform,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_Write.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Write.c
@@ -100,10 +100,10 @@ TSS2_RC Tss2_Sys_NV_Write(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_NV_BUFFER *data,
     UINT16 offset,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_NV_WriteLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_WriteLock.c
@@ -77,8 +77,8 @@ TSS2_RC Tss2_Sys_NV_WriteLock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ObjectChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_ObjectChangeAuth.c
@@ -93,10 +93,10 @@ TSS2_RC Tss2_Sys_ObjectChangeAuth(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT objectHandle,
     TPMI_DH_OBJECT parentHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_AUTH *newAuth,
     TPM2B_PRIVATE *outPrivate,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PCR_Allocate.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Allocate.c
@@ -110,13 +110,13 @@ TSS2_RC Tss2_Sys_PCR_Allocate_Complete(
 TSS2_RC Tss2_Sys_PCR_Allocate(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPML_PCR_SELECTION *pcrAllocation,
     TPMI_YES_NO *allocationSuccess,
     UINT32 *maxPCR,
     UINT32 *sizeNeeded,
     UINT32 *sizeAvailable,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PCR_Event.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Event.c
@@ -85,10 +85,10 @@ TSS2_RC Tss2_Sys_PCR_Event_Complete(
 TSS2_RC Tss2_Sys_PCR_Event(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_EVENT *eventData,
     TPML_DIGEST_VALUES *digests,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PCR_Extend.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Extend.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_PCR_Extend_Complete (
 TSS2_RC Tss2_Sys_PCR_Extend(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPML_DIGEST_VALUES *digests,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PCR_Read.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Read.c
@@ -93,12 +93,12 @@ TSS2_RC Tss2_Sys_PCR_Read_Complete(
 
 TSS2_RC Tss2_Sys_PCR_Read(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPML_PCR_SELECTION *pcrSelectionIn,
     UINT32 *pcrUpdateCounter,
     TPML_PCR_SELECTION *pcrSelectionOut,
     TPML_DIGEST *pcrValues,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PCR_Reset.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Reset.c
@@ -69,8 +69,8 @@ TSS2_RC Tss2_Sys_PCR_Reset_Complete (
 TSS2_RC Tss2_Sys_PCR_Reset(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PCR_SetAuthPolicy.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_SetAuthPolicy.c
@@ -100,11 +100,11 @@ TSS2_RC Tss2_Sys_PCR_SetAuthPolicy_Complete (
 TSS2_RC Tss2_Sys_PCR_SetAuthPolicy(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST *authPolicy,
     TPMI_ALG_HASH hashAlg,
     TPMI_DH_PCR pcrNum,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PCR_SetAuthValue.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_SetAuthValue.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_PCR_SetAuthValue_Complete (
 TSS2_RC Tss2_Sys_PCR_SetAuthValue(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_PCR pcrHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST *auth,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PP_Commands.c
+++ b/sysapi/sysapi/Tss2_Sys_PP_Commands.c
@@ -83,10 +83,10 @@ TSS2_RC Tss2_Sys_PP_Commands_Complete (
 TSS2_RC Tss2_Sys_PP_Commands(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM auth,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPML_CC *setList,
     const TPML_CC *clearList,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyAuthValue.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyAuthValue.c
@@ -69,8 +69,8 @@ TSS2_RC Tss2_Sys_PolicyAuthValue_Complete (
 TSS2_RC Tss2_Sys_PolicyAuthValue(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyAuthorize.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyAuthorize.c
@@ -107,12 +107,12 @@ TSS2_RC Tss2_Sys_PolicyAuthorize_Complete (
 TSS2_RC Tss2_Sys_PolicyAuthorize(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST *approvedPolicy,
     const TPM2B_NONCE *policyRef,
     const TPM2B_NAME *keySign,
     const TPMT_TK_VERIFIED *checkTicket,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyCommandCode.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCommandCode.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_PolicyCommandCode_Complete (
 TSS2_RC Tss2_Sys_PolicyCommandCode(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2_CC code,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyCounterTimer.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCounterTimer.c
@@ -100,11 +100,11 @@ TSS2_RC Tss2_Sys_PolicyCounterTimer_Complete (
 TSS2_RC Tss2_Sys_PolicyCounterTimer(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_OPERAND *operandB,
     UINT16 offset,
     TPM2_EO operation,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyCpHash.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCpHash.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_PolicyCpHash_Complete (
 TSS2_RC Tss2_Sys_PolicyCpHash(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST *cpHashA,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyDuplicationSelect.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyDuplicationSelect.c
@@ -100,11 +100,11 @@ TSS2_RC Tss2_Sys_PolicyDuplicationSelect_Complete (
 TSS2_RC Tss2_Sys_PolicyDuplicationSelect(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_NAME *objectName,
     const TPM2B_NAME *newParentName,
     TPMI_YES_NO includeObject,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyGetDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyGetDigest.c
@@ -78,9 +78,9 @@ TSS2_RC Tss2_Sys_PolicyGetDigest_Complete(
 TSS2_RC Tss2_Sys_PolicyGetDigest(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_DIGEST *policyDigest,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyLocality.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyLocality.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_PolicyLocality_Complete (
 TSS2_RC Tss2_Sys_PolicyLocality(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMA_LOCALITY locality,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyNV.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNV.c
@@ -116,11 +116,11 @@ TSS2_RC Tss2_Sys_PolicyNV(
     TPMI_RH_NV_AUTH authHandle,
     TPMI_RH_NV_INDEX nvIndex,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_OPERAND *operandB,
     UINT16 offset,
     TPM2_EO operation,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyNVWritten.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNVWritten.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_PolicyNVWritten_Complete (
 TSS2_RC Tss2_Sys_PolicyNvWritten(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_YES_NO writtenSet,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyNameHash.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNameHash.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_PolicyNameHash_Complete (
 TSS2_RC Tss2_Sys_PolicyNameHash(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST *nameHash,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyOR.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyOR.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_PolicyOR_Complete (
 TSS2_RC Tss2_Sys_PolicyOR(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPML_DIGEST *pHashList,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyPCR.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPCR.c
@@ -93,10 +93,10 @@ TSS2_RC Tss2_Sys_PolicyPCR_Complete (
 TSS2_RC Tss2_Sys_PolicyPCR(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST *pcrDigest,
     const TPML_PCR_SELECTION *pcrs,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyPassword.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPassword.c
@@ -69,8 +69,8 @@ TSS2_RC Tss2_Sys_PolicyPassword_Complete (
 TSS2_RC Tss2_Sys_PolicyPassword(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyPhysicalPresence.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPhysicalPresence.c
@@ -69,8 +69,8 @@ TSS2_RC Tss2_Sys_PolicyPhysicalPresence_Complete (
 TSS2_RC Tss2_Sys_PolicyPhysicalPresence(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyRestart.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyRestart.c
@@ -69,8 +69,8 @@ TSS2_RC Tss2_Sys_PolicyRestart_Complete (
 TSS2_RC Tss2_Sys_PolicyRestart(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY sessionHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicySecret.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicySecret.c
@@ -140,14 +140,14 @@ TSS2_RC Tss2_Sys_PolicySecret(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_ENTITY authHandle,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_NONCE *nonceTPM,
     const TPM2B_DIGEST *cpHashA,
     const TPM2B_NONCE *policyRef,
     INT32 expiration,
     TPM2B_TIMEOUT *timeout,
     TPMT_TK_AUTH *policyTicket,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicySigned.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicySigned.c
@@ -137,7 +137,7 @@ TSS2_RC Tss2_Sys_PolicySigned(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT authObject,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_NONCE *nonceTPM,
     const TPM2B_DIGEST *cpHashA,
     const TPM2B_NONCE *policyRef,
@@ -145,7 +145,7 @@ TSS2_RC Tss2_Sys_PolicySigned(
     const TPMT_SIGNATURE *auth,
     TPM2B_TIMEOUT *timeout,
     TPMT_TK_AUTH *policyTicket,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_PolicyTicket.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyTicket.c
@@ -114,13 +114,13 @@ TSS2_RC Tss2_Sys_PolicyTicket_Complete (
 TSS2_RC Tss2_Sys_PolicyTicket(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_SH_POLICY policySession,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_TIMEOUT *timeout,
     const TPM2B_DIGEST *cpHashA,
     const TPM2B_NONCE *policyRef,
     const TPM2B_NAME *authName,
     const TPMT_TK_AUTH *ticket,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Quote.c
+++ b/sysapi/sysapi/Tss2_Sys_Quote.c
@@ -115,13 +115,13 @@ TSS2_RC Tss2_Sys_Quote_Complete(
 TSS2_RC Tss2_Sys_Quote(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT signHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA *qualifyingData,
     const TPMT_SIG_SCHEME *inScheme,
     const TPML_PCR_SELECTION *PCRselect,
     TPM2B_ATTEST *quoted,
     TPMT_SIGNATURE *signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_RSA_Decrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_RSA_Decrypt.c
@@ -109,12 +109,12 @@ TSS2_RC Tss2_Sys_RSA_Decrypt_Complete(
 TSS2_RC Tss2_Sys_RSA_Decrypt(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_PUBLIC_KEY_RSA *cipherText,
     const TPMT_RSA_DECRYPT *inScheme,
     const TPM2B_DATA *label,
     TPM2B_PUBLIC_KEY_RSA *message,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_RSA_Encrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_RSA_Encrypt.c
@@ -108,12 +108,12 @@ TSS2_RC Tss2_Sys_RSA_Encrypt_Complete(
 TSS2_RC Tss2_Sys_RSA_Encrypt(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_PUBLIC_KEY_RSA *message,
     const TPMT_RSA_DECRYPT *inScheme,
     const TPM2B_DATA *label,
     TPM2B_PUBLIC_KEY_RSA *outData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ReadPublic.c
+++ b/sysapi/sysapi/Tss2_Sys_ReadPublic.c
@@ -91,11 +91,11 @@ TSS2_RC Tss2_Sys_ReadPublic_Complete(
 TSS2_RC Tss2_Sys_ReadPublic(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT objectHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_PUBLIC *outPublic,
     TPM2B_NAME *name,
     TPM2B_NAME *qualifiedName,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Rewrap.c
+++ b/sysapi/sysapi/Tss2_Sys_Rewrap.c
@@ -125,13 +125,13 @@ TSS2_RC Tss2_Sys_Rewrap(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT oldParent,
     TPMI_DH_OBJECT newParent,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_PRIVATE *inDuplicate,
     const TPM2B_NAME *name,
     const TPM2B_ENCRYPTED_SECRET *inSymSeed,
     TPM2B_PRIVATE *outDuplicate,
     TPM2B_ENCRYPTED_SECRET *outSymSeed,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_SelfTest.c
+++ b/sysapi/sysapi/Tss2_Sys_SelfTest.c
@@ -68,9 +68,9 @@ TSS2_RC Tss2_Sys_SelfTest_Complete (
 
 TSS2_RC Tss2_Sys_SelfTest(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_YES_NO fullTest,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_SequenceComplete.c
+++ b/sysapi/sysapi/Tss2_Sys_SequenceComplete.c
@@ -108,12 +108,12 @@ TSS2_RC Tss2_Sys_SequenceComplete_Complete(
 TSS2_RC Tss2_Sys_SequenceComplete(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT sequenceHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER *buffer,
     TPMI_RH_HIERARCHY hierarchy,
     TPM2B_DIGEST *result,
     TPMT_TK_HASHCHECK *validation,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_SequenceUpdate.c
+++ b/sysapi/sysapi/Tss2_Sys_SequenceUpdate.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_SequenceUpdate_Complete (
 TSS2_RC Tss2_Sys_SequenceUpdate(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT sequenceHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_MAX_BUFFER *buffer,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_SetAlgorithmSet.c
+++ b/sysapi/sysapi/Tss2_Sys_SetAlgorithmSet.c
@@ -76,9 +76,9 @@ TSS2_RC Tss2_Sys_SetAlgorithmSet_Complete (
 TSS2_RC Tss2_Sys_SetAlgorithmSet(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PLATFORM authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     UINT32 algorithmSet,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_SetCommandCodeAuditStatus.c
+++ b/sysapi/sysapi/Tss2_Sys_SetCommandCodeAuditStatus.c
@@ -90,11 +90,11 @@ TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus_Complete (
 TSS2_RC Tss2_Sys_SetCommandCodeAuditStatus(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_PROVISION auth,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPMI_ALG_HASH auditAlg,
     const TPML_CC *setList,
     const TPML_CC *clearList,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_SetPrimaryPolicy.c
+++ b/sysapi/sysapi/Tss2_Sys_SetPrimaryPolicy.c
@@ -93,10 +93,10 @@ TSS2_RC Tss2_Sys_SetPrimaryPolicy_Complete (
 TSS2_RC Tss2_Sys_SetPrimaryPolicy(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_RH_HIERARCHY_AUTH authHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST *authPolicy,
     TPMI_ALG_HASH hashAlg,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Shutdown.c
+++ b/sysapi/sysapi/Tss2_Sys_Shutdown.c
@@ -68,9 +68,9 @@ TSS2_RC Tss2_Sys_Shutdown_Complete (
 
 TSS2_RC Tss2_Sys_Shutdown(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2_SU shutdownType,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Sign.c
+++ b/sysapi/sysapi/Tss2_Sys_Sign.c
@@ -108,12 +108,12 @@ TSS2_RC Tss2_Sys_Sign_Complete(
 TSS2_RC Tss2_Sys_Sign(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST *digest,
     const TPMT_SIG_SCHEME *inScheme,
     const TPMT_TK_HASHCHECK *validation,
     TPMT_SIGNATURE *signature,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_StartAuthSession.c
+++ b/sysapi/sysapi/Tss2_Sys_StartAuthSession.c
@@ -139,7 +139,7 @@ TSS2_RC Tss2_Sys_StartAuthSession(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT tpmKey,
     TPMI_DH_ENTITY bind,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_NONCE *nonceCaller,
     const TPM2B_ENCRYPTED_SECRET *encryptedSalt,
     TPM2_SE sessionType,
@@ -147,7 +147,7 @@ TSS2_RC Tss2_Sys_StartAuthSession(
     TPMI_ALG_HASH authHash,
     TPMI_SH_AUTH_SESSION *sessionHandle,
     TPM2B_NONCE *nonceTPM,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_StirRandom.c
+++ b/sysapi/sysapi/Tss2_Sys_StirRandom.c
@@ -68,9 +68,9 @@ TSS2_RC Tss2_Sys_StirRandom_Complete (
 
 TSS2_RC Tss2_Sys_StirRandom(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_SENSITIVE_DATA *inData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_TestParms.c
+++ b/sysapi/sysapi/Tss2_Sys_TestParms.c
@@ -68,9 +68,9 @@ TSS2_RC Tss2_Sys_TestParms_Complete (
 
 TSS2_RC Tss2_Sys_TestParms(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPMT_PUBLIC_PARMS *parameters,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Unseal.c
+++ b/sysapi/sysapi/Tss2_Sys_Unseal.c
@@ -78,9 +78,9 @@ TSS2_RC Tss2_Sys_Unseal_Complete(
 TSS2_RC Tss2_Sys_Unseal(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT itemHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     TPM2B_SENSITIVE_DATA *outData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_Vendor_TCG_Test.c
+++ b/sysapi/sysapi/Tss2_Sys_Vendor_TCG_Test.c
@@ -76,10 +76,10 @@ TSS2_RC Tss2_Sys_Vendor_TCG_Test_Complete(
 
 TSS2_RC Tss2_Sys_Vendor_TCG_Test(
     TSS2_SYS_CONTEXT *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DATA *inputData,
     TPM2B_DATA *outputData,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_VerifySignature.c
+++ b/sysapi/sysapi/Tss2_Sys_VerifySignature.c
@@ -101,11 +101,11 @@ TSS2_RC Tss2_Sys_VerifySignature_Complete(
 TSS2_RC Tss2_Sys_VerifySignature(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyHandle,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_DIGEST *digest,
     const TPMT_SIGNATURE *signature,
     TPMT_TK_VERIFIED *validation,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi/Tss2_Sys_ZGen_2Phase.c
+++ b/sysapi/sysapi/Tss2_Sys_ZGen_2Phase.c
@@ -122,14 +122,14 @@ TSS2_RC Tss2_Sys_ZGen_2Phase_Complete(
 TSS2_RC Tss2_Sys_ZGen_2Phase(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_OBJECT keyA,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
     const TPM2B_ECC_POINT *inQsB,
     const TPM2B_ECC_POINT *inQeB,
     TPMI_ECC_KEY_EXCHANGE inScheme,
     UINT16 counter,
     TPM2B_ECC_POINT *outZ1,
     TPM2B_ECC_POINT *outZ2,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
     TSS2_RC rval;

--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -174,8 +174,8 @@ TSS2_RC CommonComplete(_TSS2_SYS_CONTEXT_BLOB *ctx)
 
 TSS2_RC CommonOneCall(
     _TSS2_SYS_CONTEXT_BLOB *ctx,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray)
+    TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
+    TSS2L_SYS_AUTH_RESPONSE *rspAuthsArray)
 {
     TSS2_RC rval;
 

--- a/test/integration/asymmetric-encrypt-decrypt.int.c
+++ b/test/integration/asymmetric-encrypt-decrypt.int.c
@@ -36,24 +36,12 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     TPM2B_PUBLIC_KEY_RSA output_message = {sizeof(TPM2B_PUBLIC_KEY_RSA)-2,};
     TPM2B_PUBLIC_KEY_RSA output_data = {sizeof(TPM2B_PUBLIC_KEY_RSA)-2,};
 
-    TPMS_AUTH_RESPONSE session_data_out;
-    TPMS_AUTH_COMMAND session_data;
-    TSS2_SYS_RSP_AUTHS sessions_data_out;
-    TSS2_SYS_CMD_AUTHS sessions_data;
-    TPMS_AUTH_COMMAND *session_data_array[1];
-    TPMS_AUTH_RESPONSE *session_data_out_array[1];
-
-    session_data_array[0] = &session_data;
-    session_data_out_array[0] = &session_data_out;
-    sessions_data_out.rspAuths = &session_data_out_array[0];
-    sessions_data.cmdAuths = &session_data_array[0];
-    sessions_data_out.rspAuthsCount = 1;
-    session_data.sessionHandle = TPM2_RS_PW;
-    session_data.nonce.size = 0;
-    session_data.hmac.size = 0;
-    *((UINT8 *)((void *)&session_data.sessionAttributes)) = 0;
-    sessions_data.cmdAuthsCount = 1;
-    sessions_data.cmdAuths[0] = &session_data;
+    TSS2L_SYS_AUTH_RESPONSE sessions_data_out;
+    TSS2L_SYS_AUTH_COMMAND sessions_data = {
+        .count = 1,
+        .auths = {{.sessionHandle = TPM2_RS_PW,
+            .nonce={.size=0},
+            .hmac={.size=0}}}};
 
     in_sensitive.size =0;
     in_sensitive.sensitive.userAuth.size = 0;
@@ -110,7 +98,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     outside_info.size = 0;
     out_public.size = 0;
     creation_data.size = 0;
-    session_data.hmac.size = 0;
+    sessions_data.auths[0].hmac.size = 0;
 
     rc = TSS2_RETRY_EXP (Tss2_Sys_Create(sapi_context, sym_handle, &sessions_data, &in_sensitive, &in_public, &outside_info, &creation_pcr, &out_private, &out_public, &creation_data, &creation_hash, &creation_ticket, &sessions_data_out));
     if (rc != TPM2_RC_SUCCESS)

--- a/test/integration/create-keyedhash-sha1-hmac.int.c
+++ b/test/integration/create-keyedhash-sha1-hmac.int.c
@@ -21,18 +21,14 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 
     /* session parameters */
     /* command session info */
-    TPMS_AUTH_COMMAND   session_cmd          = { .sessionHandle = TPM2_RS_PW };
-    TPMS_AUTH_COMMAND  *session_cmd_array[1] = { &session_cmd };
-    TSS2_SYS_CMD_AUTHS  sessions_cmd         = {
-        .cmdAuths      = session_cmd_array,
-        .cmdAuthsCount = 1
+    TSS2L_SYS_AUTH_COMMAND  sessions_cmd         = {
+        .auths = {{ .sessionHandle = TPM2_RS_PW }},
+        .count = 1
     };
     /* response session info */
-    TPMS_AUTH_RESPONSE  session_rsp          = { 0 };
-    TPMS_AUTH_RESPONSE *session_rsp_array[1] = { &session_rsp };
-    TSS2_SYS_RSP_AUTHS  sessions_rsp         = {
-        .rspAuths      = session_rsp_array,
-        .rspAuthsCount = 1
+    TSS2L_SYS_AUTH_RESPONSE  sessions_rsp         = {
+        .auths = { 0 },
+        .count = 0
     };
 
     rc = create_primary_rsa_2048_aes_128_cfb (sapi_context, &parent_handle);

--- a/test/integration/evict-ctrl.int.c
+++ b/test/integration/evict-ctrl.int.c
@@ -10,18 +10,14 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     TPM2_HANDLE  primary_handle = 0;
     /* session parameters */
     /* command session info */
-    TPMS_AUTH_COMMAND   session_cmd          = { .sessionHandle = TPM2_RS_PW };
-    TPMS_AUTH_COMMAND  *session_cmd_array[1] = { &session_cmd };
-    TSS2_SYS_CMD_AUTHS  sessions_cmd         = {
-        .cmdAuths      = session_cmd_array,
-        .cmdAuthsCount = 1
+    TSS2L_SYS_AUTH_COMMAND  sessions_cmd         = {
+        .auths = {{ .sessionHandle = TPM2_RS_PW }},
+        .count = 1
     };
     /* response session info */
-    TPMS_AUTH_RESPONSE  session_rsp          = { 0 };
-    TPMS_AUTH_RESPONSE *session_rsp_array[1] = { &session_rsp };
-    TSS2_SYS_RSP_AUTHS  sessions_rsp         = {
-        .rspAuths      = session_rsp_array,
-        .rspAuthsCount = 1
+    TSS2L_SYS_AUTH_RESPONSE  sessions_rsp         = {
+        .auths = { 0 },
+        .count = 0
     };
 
     rc = create_primary_rsa_2048_aes_128_cfb (sapi_context, &primary_handle);

--- a/test/integration/hierarchy-change-auth.int.c
+++ b/test/integration/hierarchy-change-auth.int.c
@@ -13,32 +13,16 @@ test_owner_auth (TSS2_SYS_CONTEXT *sapi_context)
 	UINT32 rval;
 	TPM2B_AUTH newAuth;
 	TPM2B_AUTH resetAuth;
-	TPMS_AUTH_COMMAND sessionData;
-	TSS2_SYS_CMD_AUTHS sessionsData;
 	int i;
 
-	TPMS_AUTH_COMMAND *sessionDataArray[1];
-
-	sessionDataArray[0] = &sessionData;
-
-	sessionsData.cmdAuths = &sessionDataArray[0];
+    TSS2L_SYS_AUTH_COMMAND sessionsData = {
+        .count = 1,
+        .auths = {{.sessionHandle = TPM2_RS_PW,
+            .sessionAttributes = 0x00,
+            .nonce={.size=0},
+            .hmac={.size=0}}}};
 
 	print_log("\nHIERARCHY_CHANGE_AUTH TESTS:\n" );
-
-	/* Init authHandle */
-	sessionData.sessionHandle = TPM2_RS_PW;
-
-	/* Init nonce */
-	sessionData.nonce.size = 0;
-
-	/* Init hmac */
-	sessionData.hmac.size = 0;
-
-	/* Init session attributes */
-	*( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0x00;
-
-	sessionsData.cmdAuthsCount = 1;
-	sessionsData.cmdAuths[0] = &sessionData;
 
 	newAuth.size = 0;
 	rval = Tss2_Sys_HierarchyChangeAuth( sapi_context, TPM2_RH_OWNER, &sessionsData, &newAuth, 0);
@@ -55,13 +39,13 @@ test_owner_auth (TSS2_SYS_CONTEXT *sapi_context)
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
 
 	/* Create hmac session */
-	sessionData.hmac = newAuth;
+	sessionsData.auths[0].hmac = newAuth;
 	rval = Tss2_Sys_HierarchyChangeAuth( sapi_context, TPM2_RH_OWNER, &sessionsData, &newAuth, 0 );
 	if (rval != TPM2_RC_SUCCESS)
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
 
 	/* Provide current auth value in SessionData hmac field */
-	sessionData.hmac = newAuth;
+	sessionsData.auths[0].hmac = newAuth;
 	/* change auth value to different value */
 	newAuth.buffer[0] = 3;
 	rval = Tss2_Sys_HierarchyChangeAuth( sapi_context, TPM2_RH_OWNER, &sessionsData, &newAuth, 0 );
@@ -69,7 +53,7 @@ test_owner_auth (TSS2_SYS_CONTEXT *sapi_context)
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
 
 	/* Provide current auth value in SessionData hmac field */
-	sessionData.hmac = newAuth;
+	sessionsData.auths[0].hmac = newAuth;
 	/* change auth value to different value */
 	newAuth.buffer[0] = 4;
 	/* backup auth value to restore to empty buffer after test */
@@ -86,7 +70,6 @@ test_owner_auth (TSS2_SYS_CONTEXT *sapi_context)
 	if (rval != (TPM2_RC_1 + TPM2_RC_S + TPM2_RC_BAD_AUTH))
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
 
-	sessionsData.cmdAuths[0] = &sessionData;
 	rval = Tss2_Sys_HierarchyChangeAuth( sapi_context, TPM2_RH_OWNER, &sessionsData, &newAuth, 0 );
 	if (rval != (TPM2_RC_1 + TPM2_RC_S + TPM2_RC_BAD_AUTH))
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
@@ -97,7 +80,7 @@ test_owner_auth (TSS2_SYS_CONTEXT *sapi_context)
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
 
 	/* Set auth to zero again with valid session */
-	sessionData.hmac = resetAuth;
+	sessionsData.auths[0].hmac = resetAuth;
 	/* change auth value to different value */
 	newAuth.size = 0;
 	rval = Tss2_Sys_HierarchyChangeAuth( sapi_context, TPM2_RH_OWNER, &sessionsData, &newAuth, 0 );
@@ -116,32 +99,16 @@ test_platform_auth (TSS2_SYS_CONTEXT *sapi_context)
 	UINT32 rval;
 	TPM2B_AUTH newAuth;
 	TPM2B_AUTH resetAuth;
-	TPMS_AUTH_COMMAND sessionData;
-	TSS2_SYS_CMD_AUTHS sessionsData;
 	int i;
 
-	TPMS_AUTH_COMMAND *sessionDataArray[1];
-
-	sessionDataArray[0] = &sessionData;
-
-	sessionsData.cmdAuths = &sessionDataArray[0];
+    TSS2L_SYS_AUTH_COMMAND sessionsData = {
+        .count = 1,
+        .auths = {{.sessionHandle = TPM2_RS_PW,
+            .sessionAttributes = 0x00,
+            .nonce={.size=0},
+            .hmac={.size=0}}}};
 
 	print_log("\nHIERARCHY_CHANGE_AUTH TESTS:\n" );
-
-	/* Init authHandle */
-	sessionData.sessionHandle = TPM2_RS_PW;
-
-	/* Init nonce */
-	sessionData.nonce.size = 0;
-
-	/* Init hmac */
-	sessionData.hmac.size = 0;
-
-	/* Init session attributes */
-	*( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-
-	sessionsData.cmdAuthsCount = 1;
-	sessionsData.cmdAuths[0] = &sessionData;
 
 	newAuth.size = 0;
 	rval = Tss2_Sys_HierarchyChangeAuth( sapi_context, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0);
@@ -158,13 +125,13 @@ test_platform_auth (TSS2_SYS_CONTEXT *sapi_context)
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
 
 	/* Create hmac session */
-	sessionData.hmac = newAuth;
+	sessionsData.auths[0].hmac = newAuth;
 	rval = Tss2_Sys_HierarchyChangeAuth( sapi_context, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
 	if (rval != TPM2_RC_SUCCESS)
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
 
 	/* Provide current auth value in SessionData hmac field */
-	sessionData.hmac = newAuth;
+	sessionsData.auths[0].hmac = newAuth;
 	/* change auth value to different value */
 	newAuth.buffer[0] = 3;
 	rval = Tss2_Sys_HierarchyChangeAuth( sapi_context, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
@@ -172,7 +139,7 @@ test_platform_auth (TSS2_SYS_CONTEXT *sapi_context)
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
 
 	/* Provide current auth value in SessionData hmac field */
-	sessionData.hmac = newAuth;
+	sessionsData.auths[0].hmac = newAuth;
 	/* change auth value to different value */
 	newAuth.buffer[0] = 4;
 	/* backup auth value to restore to empty buffer after test */
@@ -189,7 +156,6 @@ test_platform_auth (TSS2_SYS_CONTEXT *sapi_context)
 	if (rval != (TPM2_RC_1 + TPM2_RC_S + TPM2_RC_BAD_AUTH))
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
 
-	sessionsData.cmdAuths[0] = &sessionData;
 	rval = Tss2_Sys_HierarchyChangeAuth( sapi_context, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
 	if (rval != (TPM2_RC_1 + TPM2_RC_S + TPM2_RC_BAD_AUTH))
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
@@ -200,7 +166,7 @@ test_platform_auth (TSS2_SYS_CONTEXT *sapi_context)
 		print_fail("HierarchyChangeAuth FAILED! Response Code : 0x%x", rval);
 
 	/* Set auth to zero again with valid session */
-	sessionData.hmac = resetAuth;
+	sessionsData.auths[0].hmac = resetAuth;
 	/* change auth value to different value */
 	newAuth.size = 0;
 	rval = Tss2_Sys_HierarchyChangeAuth( sapi_context, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );

--- a/test/integration/sapi-util.c
+++ b/test/integration/sapi-util.c
@@ -49,18 +49,14 @@ create_primary_rsa_2048_aes_128_cfb (
     TPM2B_NAME              name            = TPM2B_NAME_INIT;
     /* session parameters */
     /* command session info */
-    TPMS_AUTH_COMMAND   session_cmd = { .sessionHandle = TPM2_RS_PW };
-    TPMS_AUTH_COMMAND  *session_cmd_array[1] = { &session_cmd };
-    TSS2_SYS_CMD_AUTHS  sessions_cmd = {
-        .cmdAuths      = session_cmd_array,
-        .cmdAuthsCount = 1
+    TSS2L_SYS_AUTH_COMMAND  sessions_cmd = {
+        .auths = {{ .sessionHandle = TPM2_RS_PW }},
+        .count = 1
     };
     /* response session info */
-    TPMS_AUTH_RESPONSE  session_rsp          = { 0 };
-    TPMS_AUTH_RESPONSE *session_rsp_array[1] = { &session_rsp };
-    TSS2_SYS_RSP_AUTHS  sessions_rsp     = {
-        .rspAuths      = session_rsp_array,
-        .rspAuthsCount = 1
+    TSS2L_SYS_AUTH_RESPONSE  sessions_rsp     = {
+        .auths = { 0 },
+        .count = 0
     };
 
     if (sapi_context == NULL || handle == NULL) {
@@ -139,18 +135,14 @@ create_aes_128_cfb (
     TPM2B_NAME              name            = TPM2B_NAME_INIT;
     /* session parameters */
     /* command session info */
-    TPMS_AUTH_COMMAND   session_cmd = { .sessionHandle = TPM2_RS_PW };
-    TPMS_AUTH_COMMAND  *session_cmd_array[1] = { &session_cmd };
-    TSS2_SYS_CMD_AUTHS  sessions_cmd = {
-        .cmdAuths      = session_cmd_array,
-        .cmdAuthsCount = 1
+    TSS2L_SYS_AUTH_COMMAND  sessions_cmd = {
+        .auths = {{ .sessionHandle = TPM2_RS_PW }},
+        .count = 1
     };
     /* response session info */
-    TPMS_AUTH_RESPONSE  session_rsp          = { 0 };
-    TPMS_AUTH_RESPONSE *session_rsp_array[1] = { &session_rsp };
-    TSS2_SYS_RSP_AUTHS  sessions_rsp     = {
-        .rspAuths      = session_rsp_array,
-        .rspAuthsCount = 1
+    TSS2L_SYS_AUTH_RESPONSE  sessions_rsp     = {
+        .auths = { 0 },
+        .count = 0
     };
 
     rc = TSS2_RETRY_EXP (Tss2_Sys_Create (sapi_context,
@@ -194,18 +186,15 @@ encrypt_decrypt_cfb (
 
     /* session parameters */
     /* command session info */
-    TPMS_AUTH_COMMAND   session_cmd = { .sessionHandle = TPM2_RS_PW };
-    TPMS_AUTH_COMMAND  *session_cmd_array[1] = { &session_cmd };
-    TSS2_SYS_CMD_AUTHS  sessions_cmd = {
-        .cmdAuths = session_cmd_array,
-        .cmdAuthsCount = 1
+    /* command session info */
+    TSS2L_SYS_AUTH_COMMAND  sessions_cmd = {
+        .auths = {{ .sessionHandle = TPM2_RS_PW }},
+        .count = 1
     };
     /* response session info */
-    TPMS_AUTH_RESPONSE  session_rsp = { 0 };
-    TPMS_AUTH_RESPONSE *session_rsp_array[1] = { &session_rsp };
-    TSS2_SYS_RSP_AUTHS  sessions_rsp = {
-        .rspAuths = session_rsp_array,
-        .rspAuthsCount = 1
+    TSS2L_SYS_AUTH_RESPONSE  sessions_rsp     = {
+        .auths = { 0 },
+        .count = 0
     };
 
     return Tss2_Sys_EncryptDecrypt (sapi_context,
@@ -254,18 +243,15 @@ encrypt_decrypt_2_cfb (
 
     /* session parameters */
     /* command session info */
-    TPMS_AUTH_COMMAND   session_cmd = { .sessionHandle = TPM2_RS_PW };
-    TPMS_AUTH_COMMAND  *session_cmd_array[1] = { &session_cmd };
-    TSS2_SYS_CMD_AUTHS  sessions_cmd = {
-        .cmdAuths = session_cmd_array,
-        .cmdAuthsCount = 1
+    /* command session info */
+    TSS2L_SYS_AUTH_COMMAND  sessions_cmd = {
+        .auths = {{ .sessionHandle = TPM2_RS_PW }},
+        .count = 1
     };
     /* response session info */
-    TPMS_AUTH_RESPONSE  session_rsp = { 0 };
-    TPMS_AUTH_RESPONSE *session_rsp_array[1] = { &session_rsp };
-    TSS2_SYS_RSP_AUTHS  sessions_rsp = {
-        .rspAuths = session_rsp_array,
-        .rspAuthsCount = 1
+    TSS2L_SYS_AUTH_RESPONSE  sessions_rsp     = {
+        .auths = { 0 },
+        .count = 0
     };
 
     return Tss2_Sys_EncryptDecrypt2 (sapi_context,

--- a/test/tpmclient/DecryptEncrypt.c
+++ b/test/tpmclient/DecryptEncrypt.c
@@ -141,15 +141,10 @@ TSS2_RC EncryptCFB( SESSION *session, TPM2B_MAX_BUFFER *encryptedData, TPM2B_MAX
     TPM2B_NAME keyName;
     TSS2_SYS_CONTEXT *sysContext;
 
-    // Authorization structure for command.
-    TPMS_AUTH_COMMAND sessionData;
-
-    // Create and init authorization area for command:
-    // only 1 authorization area.
-    TPMS_AUTH_COMMAND *sessionDataArray[1] = { &sessionData };
-
     // Authorization array for command (only has one auth structure).
-    TSS2_SYS_CMD_AUTHS sessionsData = { 1, &sessionDataArray[0] };
+    TSS2L_SYS_AUTH_COMMAND sessionsData = {
+        .count = 1,
+        .auths = { 0 }};
 
     sysContext = InitSysContext( 1000, resMgrTctiContext, &abiVersion );
     if( sysContext == 0 )
@@ -166,10 +161,10 @@ TSS2_RC EncryptCFB( SESSION *session, TPM2B_MAX_BUFFER *encryptedData, TPM2B_MAX
         if( rval == TSS2_RC_SUCCESS )
         {
             // Encrypt the data.
-            sessionData.sessionHandle = TPM2_RS_PW;
-            sessionData.nonce.size = 0;
-            *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-            sessionData.hmac.size = 0;
+            sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
+            sessionsData.auths[0].nonce.size = 0;
+            sessionsData.auths[0].sessionAttributes = 0;
+            sessionsData.auths[0].hmac.size = 0;
             encryptedData->size = sizeof( *encryptedData ) - 1;
             INIT_SIMPLE_TPM2B_SIZE( ivOut );
             rval = Tss2_Sys_EncryptDecrypt( sysContext, keyHandle, &sessionsData, NO, TPM2_ALG_CFB, &ivIn,
@@ -193,17 +188,10 @@ TSS2_RC DecryptCFB( SESSION *session, TPM2B_MAX_BUFFER *clearData, TPM2B_MAX_BUF
     TPM2_HANDLE keyHandle;
     TPM2B_NAME keyName;
     TSS2_SYS_CONTEXT *sysContext;
-
-    // Authorization structure for command.
-    TPMS_AUTH_COMMAND sessionData;
-
-    // Create and init authorization area for command:
-    // only 1 authorization area.
-    TPMS_AUTH_COMMAND *sessionDataArray[1] = { &sessionData };
-
-    // Authorization array for command (only has one auth structure).
-    TSS2_SYS_CMD_AUTHS sessionsData = { 1, &sessionDataArray[0] };
-
+   // Authorization array for command (only has one auth structure).
+     TSS2L_SYS_AUTH_COMMAND sessionsData = {
+        .count = 1,
+        .auths = { 0 }};
 
     sysContext = InitSysContext( 1000, resMgrTctiContext, &abiVersion );
     if( sysContext == 0 )
@@ -220,10 +208,10 @@ TSS2_RC DecryptCFB( SESSION *session, TPM2B_MAX_BUFFER *clearData, TPM2B_MAX_BUF
         if( rval == TSS2_RC_SUCCESS )
         {
             // Decrypt the data.
-            sessionData.sessionHandle = TPM2_RS_PW;
-            sessionData.nonce.size = 0;
-            *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-            sessionData.hmac.size = 0;
+            sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
+            sessionsData.auths[0].nonce.size = 0;
+            sessionsData.auths[0].sessionAttributes = 0;
+            sessionsData.auths[0].hmac.size = 0;
 
             INIT_SIMPLE_TPM2B_SIZE( ivOut );
             rval = Tss2_Sys_EncryptDecrypt( sysContext, keyHandle, &sessionsData, YES, TPM2_ALG_CFB, &ivIn,

--- a/test/tpmclient/SessionHmac.c
+++ b/test/tpmclient/SessionHmac.c
@@ -165,7 +165,7 @@ UINT32 TpmComputeSessionHmac(
 
 
 TSS2_RC ComputeCommandHmacs( TSS2_SYS_CONTEXT *sysContext, TPM2_HANDLE handle1,
-    TPM2_HANDLE handle2, TSS2_SYS_CMD_AUTHS *pSessionsDataIn,
+    TPM2_HANDLE handle2, TSS2L_SYS_AUTH_COMMAND *pSessionsDataIn,
     TSS2_RC sessionCmdRval )
 {
     uint8_t i;
@@ -175,16 +175,16 @@ TSS2_RC ComputeCommandHmacs( TSS2_SYS_CONTEXT *sysContext, TPM2_HANDLE handle1,
 
     // Note:  from Part 1, table 6, Use of Authorization/Session Blocks, we
     // can have at most two HMAC sessions per command.
-    for( i = 0; ( i < 2 ) && ( i < pSessionsDataIn->cmdAuthsCount ); i++ )
+    for( i = 0; ( i < 2 ) && ( i < pSessionsDataIn->count ); i++ )
     {
-        authPtr = &( pSessionsDataIn->cmdAuths[i]->hmac );
+        authPtr = &( pSessionsDataIn->auths[i].hmac );
         entityHandle = handle1;
 
         if( authPtr != 0 )
         {
-            rval = TpmComputeSessionHmac( sysContext,  pSessionsDataIn->cmdAuths[i],
+            rval = TpmComputeSessionHmac( sysContext,  &pSessionsDataIn->auths[i],
                     entityHandle, TPM2_RC_NO_RESPONSE, handle1, handle2,
-                    pSessionsDataIn->cmdAuths[i]->sessionAttributes,
+                    pSessionsDataIn->auths[i].sessionAttributes,
                     authPtr, sessionCmdRval );
             if( rval != TPM2_RC_SUCCESS )
                 break;
@@ -196,8 +196,8 @@ TSS2_RC ComputeCommandHmacs( TSS2_SYS_CONTEXT *sysContext, TPM2_HANDLE handle1,
 
 
 TSS2_RC CheckResponseHMACs( TSS2_SYS_CONTEXT *sysContext, TSS2_RC responseCode,
-    TSS2_SYS_CMD_AUTHS *pSessionsDataIn, TPM2_HANDLE handle1, TPM2_HANDLE handle2,
-    TSS2_SYS_RSP_AUTHS *pSessionsDataOut )
+    TSS2L_SYS_AUTH_COMMAND *pSessionsDataIn, TPM2_HANDLE handle1, TPM2_HANDLE handle2,
+    TSS2L_SYS_AUTH_RESPONSE *pSessionsDataOut )
 {
     TPM2_HANDLE entityHandle = TPM2_HT_NO_HANDLE;
     TPM2B_DIGEST auth;
@@ -207,21 +207,21 @@ TSS2_RC CheckResponseHMACs( TSS2_SYS_CONTEXT *sysContext, TSS2_RC responseCode,
     // Check response HMACs, if any.
     if( responseCode == TPM2_RC_SUCCESS )
     {
-        for( i = 0; ( i < 2 ) && ( i < pSessionsDataIn->cmdAuthsCount ); i++ )
+        for( i = 0; ( i < 2 ) && ( i < pSessionsDataIn->count ); i++ )
         {
             entityHandle = handle1;
 
-            if( ( pSessionsDataIn->cmdAuths[i]->sessionHandle >> TPM2_HR_SHIFT ) == TPM2_HT_HMAC_SESSION )
+            if( ( pSessionsDataIn->auths[i].sessionHandle >> TPM2_HR_SHIFT ) == TPM2_HT_HMAC_SESSION )
             {
                 rval = TpmComputeSessionHmac( sysContext,
-                        pSessionsDataIn->cmdAuths[i], entityHandle,
+                        &pSessionsDataIn->auths[i], entityHandle,
                         responseCode, handle1, handle2,
-                        pSessionsDataOut->rspAuths[i]->sessionAttributes,
+                        pSessionsDataOut->auths[i].sessionAttributes,
                         &auth, TPM2_RC_SUCCESS );
                 if( rval != TPM2_RC_SUCCESS )
                     return rval;
 
-                rval = CompareSizedByteBuffer((TPM2B *)&auth, (TPM2B *)&pSessionsDataOut->rspAuths[i]->hmac);
+                rval = CompareSizedByteBuffer((TPM2B *)&auth, (TPM2B *)&pSessionsDataOut->auths[i].hmac);
                 if( rval != TPM2_RC_SUCCESS )
                     return APPLICATION_HMAC_ERROR(i+1);
             }

--- a/test/tpmclient/TpmHash.c
+++ b/test/tpmclient/TpmHash.c
@@ -69,21 +69,17 @@ UINT32 TpmHashSequence( TPMI_ALG_HASH hashAlg, UINT8 numBuffers, TPM2B_DIGEST *b
     TPM2B emptyBuffer;
     TPMT_TK_HASHCHECK validation;
 
-    TPMS_AUTH_COMMAND cmdAuth;
-    TPMS_AUTH_COMMAND *cmdSessionArray[1] = { &cmdAuth };
-    TSS2_SYS_CMD_AUTHS cmdAuthArray = { 1, &cmdSessionArray[0] };
+    TSS2L_SYS_AUTH_COMMAND cmdAuthArray = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
 
     nullAuth.size = 0;
     emptyBuffer.size = 0;
 
     // Set result size to 0, in case any errors occur
     result->size = 0;
-
-    // Init input sessions struct
-    cmdAuth.sessionHandle = TPM2_RS_PW;
-    cmdAuth.nonce.size = 0;
-    *(UINT8 *)((void *)&cmdAuth.sessionAttributes) = 0;
-    cmdAuth.hmac.size = 0;
 
     sysContext = InitSysContext( 3000, resMgrTctiContext, &abiVersion );
     if( sysContext == 0 )

--- a/test/tpmclient/sample.h
+++ b/test/tpmclient/sample.h
@@ -148,7 +148,7 @@ TSS2_RC GetSessionStruct( TPMI_SH_AUTH_SESSION authHandle, SESSION **pSession );
 TSS2_RC GetSessionAlgId( TPMI_SH_AUTH_SESSION authHandle, TPMI_ALG_HASH *sessionAlgId );
 TSS2_RC EndAuthSession( SESSION *session );
 TSS2_RC ComputeCommandHmacs( TSS2_SYS_CONTEXT *sysContext, TPM2_HANDLE handle1,
-    TPM2_HANDLE handle2, TSS2_SYS_CMD_AUTHS *pSessionsData,
+    TPM2_HANDLE handle2, TSS2L_SYS_AUTH_COMMAND *pSessionsData,
     TSS2_RC sessionCmdRval );
 
 extern INT16 sessionEntriesUsed;
@@ -173,8 +173,8 @@ extern UINT32 ( *ComputeSessionHmacPtr )(
 
 extern TSS2_RC CheckResponseHMACs( TSS2_SYS_CONTEXT *sysContext,
     TSS2_RC responseCode,
-    TSS2_SYS_CMD_AUTHS *pSessionsDataIn, TPM2_HANDLE handle1, TPM2_HANDLE handle2,
-    TSS2_SYS_RSP_AUTHS *pSessionsDataOut );
+    TSS2L_SYS_AUTH_COMMAND *pSessionsDataIn, TPM2_HANDLE handle1, TPM2_HANDLE handle2,
+    TSS2L_SYS_AUTH_RESPONSE *pSessionsDataOut );
 
 TSS2_RC StartAuthSessionWithParams( SESSION **session, TPMI_DH_OBJECT tpmKey, TPM2B_MAX_BUFFER *salt,
     TPMI_DH_ENTITY bind, TPM2B_AUTH *bindAuth, TPM2B_NONCE *nonceCaller, TPM2B_ENCRYPTED_SECRET *encryptedSalt,

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -225,12 +225,8 @@ void Delay( UINT16 delay)
     Delay(0);							\
   }
 
-TPMS_AUTH_COMMAND nullSessionData;
-TPMS_AUTH_RESPONSE nullSessionDataOut;
-TPMS_AUTH_COMMAND *nullSessionDataArray[1] = { &nullSessionData };
-TPMS_AUTH_RESPONSE *nullSessionDataOutArray[1] = { &nullSessionDataOut };
-TSS2_SYS_CMD_AUTHS nullSessionsData = { 1, &nullSessionDataArray[0] };
-TSS2_SYS_RSP_AUTHS nullSessionsDataOut = { 1, &nullSessionDataOutArray[0] };
+TSS2L_SYS_AUTH_COMMAND nullSessionsData = { 1, { 0 } };
+TSS2L_SYS_AUTH_RESPONSE nullSessionsDataOut = { 0, { 0 } };
 TPM2B_NONCE nullSessionNonce, nullSessionNonceOut;
 TPM2B_AUTH nullSessionHmac;
 
@@ -264,38 +260,15 @@ TSS2_RC TpmReset()
 void TestDictionaryAttackLockReset()
 {
     UINT32 rval;
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
 
     DebugPrintf( NO_PREFIX, "\nDICTIONARY ATTACK LOCK RESET TEST  :\n" );
-
-    // Init authHandle
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionData.nonce.size = 0;
-
-    // init hmac
-    sessionData.hmac.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &sessionData;
 
     rval = Tss2_Sys_DictionaryAttackLockReset ( sysContext, TPM2_RH_LOCKOUT, &sessionsData, &sessionsDataOut );
     CheckPassed( rval );
@@ -438,43 +411,17 @@ void TestTpmGetCapability()
 void TestTpmClear()
 {
     UINT32 rval;
-    TPM2B_AUTH      hmac;
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TPM2B_NONCE     nonce;
-    TSS2_SYS_CMD_AUTHS sessionsDataIn;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TPM2B_AUTH      hmac = { .size = 0 };
+    TPM2B_NONCE     nonce = { .size = 0 };
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsDataIn.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
-    sessionsDataOut.rspAuths[0] = &sessionDataOut;
+    TSS2L_SYS_AUTH_COMMAND sessionsDataIn = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce=nonce,
+        .hmac=hmac}}};
 
     DebugPrintf( NO_PREFIX, "\nCLEAR and CLEAR CONTROL TESTS:\n" );
-
-    // Init sessionHandle
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    nonce.size = 0;
-    sessionData.nonce = nonce;
-
-    // init hmac
-    hmac.size = 0;
-    sessionData.hmac = hmac;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-
-    sessionsDataIn.cmdAuthsCount = 1;
-    sessionsDataIn.cmdAuths[0] = &sessionData;
 
     rval = Tss2_Sys_Clear ( sysContext, TPM2_RH_PLATFORM, &sessionsDataIn, 0 );
     CheckPassed( rval );
@@ -488,17 +435,12 @@ void TestTpmClear()
     rval = Tss2_Sys_ClearControl ( sysContext, TPM2_RH_PLATFORM, &sessionsDataIn, NO, &sessionsDataOut );
     CheckPassed( rval );
 
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0xff;
-    sessionsDataIn.cmdAuths[0] = &sessionData;
+    sessionsDataIn.auths[0].sessionAttributes = 0xff;
     rval = Tss2_Sys_Clear ( sysContext, TPM2_RH_PLATFORM, &sessionsDataIn, &sessionsDataOut );
     CheckFailed( rval, TPM2_RC_9 + TPM2_RC_RESERVED_BITS );
 
     rval = Tss2_Sys_ClearControl ( sysContext, TPM2_RH_PLATFORM, &sessionsDataIn, NO, &sessionsDataOut );
     CheckFailed( rval, TPM2_RC_9 + TPM2_RC_RESERVED_BITS );
-
-    hmac.size = 0;
-
-
 }
 
 #define SESSIONS_ABOVE_MAX_ACTIVE 0
@@ -612,38 +554,14 @@ void TestStartAuthSession()
 void TestChangeEps()
 {
     UINT32 rval;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     DebugPrintf( NO_PREFIX, "\nCHANGE_EPS TESTS:\n" );
-
-	sessionsData.cmdAuthsCount = 1;
-
-    // Init authHandle
-    sessionsData.cmdAuths[0]->sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionsData.cmdAuths[0]->nonce.size = 0;
-
-    // init hmac
-    sessionsData.cmdAuths[0]->hmac.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionsData.cmdAuths[0]->sessionAttributes ) ) = 0;
 
     rval = Tss2_Sys_ChangeEPS( sysContext, TPM2_RH_PLATFORM, &sessionsData, &sessionsDataOut );
     CheckPassed( rval );
@@ -652,39 +570,16 @@ void TestChangeEps()
 void TestChangePps()
 {
     UINT32 rval;
-    TSS2_SYS_CMD_AUTHS sessionsData;
 
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     DebugPrintf( NO_PREFIX, "\nCHANGE_PPS TESTS:\n" );
-
-    sessionsData.cmdAuthsCount = 1;
-
-    // Init authHandle
-    sessionsData.cmdAuths[0]->sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionsData.cmdAuths[0]->nonce.size = 0;
-
-    // init hmac
-    sessionsData.cmdAuths[0]->hmac.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionsData.cmdAuths[0]->sessionAttributes ) ) = 0;
 
     rval = Tss2_Sys_ChangePPS( sysContext, TPM2_RH_PLATFORM, &sessionsData, &sessionsDataOut );
     CheckPassed( rval );
@@ -694,32 +589,15 @@ void TestHierarchyChangeAuth()
 {
     UINT32 rval;
     TPM2B_AUTH      newAuth;
-    TPMS_AUTH_COMMAND sessionData;
-    TSS2_SYS_CMD_AUTHS sessionsData;
     int i;
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-
-    sessionDataArray[0] = &sessionData;
-
-    sessionsData.cmdAuths = &sessionDataArray[0];
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     DebugPrintf( NO_PREFIX, "\nHIERARCHY_CHANGE_AUTH TESTS:\n" );
-
-    // Init authHandle
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionData.nonce.size = 0;
-
-    // init hmac
-    sessionData.hmac.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &sessionData;
 
     newAuth.size = 0;
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
@@ -733,7 +611,7 @@ void TestHierarchyChangeAuth()
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
     CheckPassed( rval );
 
-    sessionData.hmac = newAuth;
+    sessionsData.auths[0].hmac = newAuth;
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
     CheckPassed( rval );
 
@@ -743,7 +621,6 @@ void TestHierarchyChangeAuth()
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
     CheckPassed( rval );
 
-    sessionsData.cmdAuths[0] = &sessionData;
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM2_RH_PLATFORM, &sessionsData, &newAuth, 0 );
     CheckFailed( rval, TPM2_RC_1 + TPM2_RC_S + TPM2_RC_BAD_AUTH );
 
@@ -776,8 +653,6 @@ void TestHierarchyChangeAuth()
 void TestPcrExtend()
 {
     UINT32 rval;
-    TPMS_AUTH_COMMAND sessionData;
-    TSS2_SYS_CMD_AUTHS sessionsData;
     UINT16 i, digestSize;
     TPML_PCR_SELECTION  pcrSelection;
     UINT32 pcrUpdateCounterBeforeExtend;
@@ -788,24 +663,13 @@ void TestPcrExtend()
     TPML_DIGEST_VALUES digests;
     TPML_PCR_SELECTION pcrSelectionOut;
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionsData.cmdAuths = &sessionDataArray[0];
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     DebugPrintf( NO_PREFIX, "\nPCR_EXTEND, PCR_EVENT, PCR_ALLOCATE, and PCR_READ TESTS:\n" );
-
-    // Init authHandle
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionData.nonce.size = 0;
-
-    // init hmac
-    sessionData.hmac.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
 
     // Init digests
     digests.count = 1;
@@ -835,9 +699,6 @@ void TestPcrExtend()
     if( pcrValues.digests[0].size <= PCR_SIZE &&
             pcrValues.digests[0].size <= sizeof( pcrValues.digests[0].buffer ) )
         memcpy( &( pcrBeforeExtend[0] ), &( pcrValues.digests[0].buffer[0] ), pcrValues.digests[0].size );
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &sessionData;
 
     rval = Tss2_Sys_PCR_Extend( sysContext, PCR_17, &sessionsData, &digests, 0  );
     CheckPassed( rval );
@@ -877,16 +738,7 @@ void TestPcrExtend()
 void TestShutdown()
 {
     UINT32 rval;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-    TPMS_AUTH_RESPONSE sessionDataOut;
-
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     DebugPrintf( NO_PREFIX, "\nSHUTDOWN TESTS:\n" );
 
@@ -905,10 +757,7 @@ void TestNV()
     UINT32 rval;
     TPM2B_NV_PUBLIC publicInfo;
     TPM2B_AUTH  nvAuth;
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
     int i;
     TPM2B_MAX_NV_BUFFER nvWriteData;
     TPM2B_MAX_NV_BUFFER nvData;
@@ -916,16 +765,11 @@ void TestNV()
     TPM2B_NV_PUBLIC nvPublic;
     TPM2B_NAME nvName;
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     DebugPrintf( NO_PREFIX, "\nNV INDEX TESTS:\n" );
 
@@ -951,20 +795,6 @@ void TestNV()
     publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_ORDERLY;
     publicInfo.nvPublic.authPolicy.size = 0;
     publicInfo.nvPublic.dataSize = 32;
-
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionData.nonce.size = 0;
-
-    // init hmac
-    sessionData.hmac.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &sessionData;
 
     INIT_SIMPLE_TPM2B_SIZE( nvData );
     rval = Tss2_Sys_NV_Read( sysContext, TPM2_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut );
@@ -1067,25 +897,17 @@ void TestHierarchyControl()
     UINT32 rval;
     TPM2B_NV_PUBLIC publicInfo;
     TPM2B_AUTH  nvAuth;
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
     int i;
     TPM2B_NAME nvName;
     TPM2B_NV_PUBLIC nvPublic;
     TPM2B_MAX_NV_BUFFER nvData;
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     DebugPrintf( NO_PREFIX, "\nHIERARCHY CONTROL TESTS:\n" );
 
@@ -1112,20 +934,6 @@ void TestHierarchyControl()
     publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_ORDERLY;
     publicInfo.nvPublic.authPolicy.size = 0;
     publicInfo.nvPublic.dataSize = 32;
-
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionData.nonce.size = 0;
-
-    // init hmac
-    sessionData.hmac.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &sessionData;
 
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM2_RH_PLATFORM, &sessionsData, &nvAuth, &publicInfo, 0 );
     CheckPassed( rval );
@@ -1175,11 +983,7 @@ void TestCreate(){
     TPM2B_SENSITIVE_CREATE  inSensitive = {sizeof( TPM2B_SENSITIVE_CREATE ) - 2,};
     TPM2B_DATA              outsideInfo = {sizeof( TPM2B_DATA ) - 2,};
     TPML_PCR_SELECTION      creationPCR;
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 	TPM2B_NAME name = {sizeof( TPM2B_NAME ) - 2,};
 	TPM2B_NAME name1 = {sizeof( TPM2B_NAME ) - 2,};
     TPM2B_PRIVATE outPrivate = {sizeof( TPM2B_PRIVATE ) - 2,};
@@ -1188,16 +992,11 @@ void TestCreate(){
 	TPM2B_DIGEST creationHash = {sizeof( TPM2B_DIGEST ) - 2,};
 	TPMT_TK_CREATION creationTicket = { 0, 0, {sizeof( TPM2B_DIGEST ) - 2,} };
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     DebugPrintf( NO_PREFIX, "\nCREATE, CREATE PRIMARY, and LOAD TESTS:\n" );
 
@@ -1231,20 +1030,6 @@ void TestCreate(){
 
     outsideInfo.size = 0;
     creationPCR.count = 0;
-
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionData.nonce.size = 0;
-
-    // init hmac
-    sessionData.hmac.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &sessionData;
 
     // Do SAPI test for non-zero sized outPublic
     outPublic.size = 0xff;
@@ -1283,9 +1068,9 @@ void TestCreate(){
     DebugPrintf( NO_PREFIX, "\nNew key successfully created in platform hierarchy (RSA 2048).  Handle: 0x%8.8x\n",
             handle2048rsa );
 
-    sessionData.hmac.size = 2;
-    sessionData.hmac.buffer[0] = 0x00;
-    sessionData.hmac.buffer[1] = 0xff;
+    sessionsData.auths[0].hmac.size = 2;
+    sessionsData.auths[0].hmac.buffer[0] = 0x00;
+    sessionsData.auths[0].hmac.buffer[1] = 0xff;
 
     inPublic.publicArea.type = TPM2_ALG_KEYEDHASH;
     inPublic.publicArea.objectAttributes &= ~TPMA_OBJECT_DECRYPT;
@@ -1325,32 +1110,20 @@ void TestCreate(){
 void TestEvict()
 {
     TSS2_RC rval = TPM2_RC_SUCCESS;
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-    sessionsData.cmdAuthsCount = 1;
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     DebugPrintf( NO_PREFIX, "\nEVICT CONTROL TESTS:\n" );
-
-    sessionData.sessionHandle = TPM2_RS_PW;
-    sessionData.nonce.size = 0;
-    sessionData.hmac.size = 0;
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
 
     rval = Tss2_Sys_EvictControl( sysContext, TPM2_RH_PLATFORM, handle2048rsa, &sessionsData, 0x81800000, &sessionsDataOut );
     CheckPassed( rval );
 
     // Reset persistent key to be transitent.
-    sessionData.hmac.size = 0;
+    sessionsData.auths[0].hmac.size = 0;
     rval = Tss2_Sys_EvictControl( sysContext, TPM2_RH_PLATFORM, 0x81800000, &sessionsData, 0x81800000, &sessionsDataOut );
     CheckPassed( rval );
 }
@@ -1362,18 +1135,12 @@ TSS2_RC DefineNvIndex( TPMI_RH_PROVISION authHandle, TPMI_SH_AUTH_SESSION sessio
     TPM2B_NV_PUBLIC publicInfo;
 
     // Command and response session data structures.
-    TPMS_AUTH_COMMAND sessionData = { sessionAuthHandle, };
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TPMS_AUTH_COMMAND *sessionDataArray[1] = { &sessionData };
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1] = { &sessionDataOut };
-    TSS2_SYS_CMD_AUTHS sessionsData = { 1, &sessionDataArray[0] };
-    TSS2_SYS_RSP_AUTHS sessionsDataOut = { 1, &sessionDataOutArray[0] };
-    // Init nonce.
-    sessionData.nonce.size = 0;
-    // init hmac
-    sessionData.hmac.size = 0;
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     attributes |= TPMA_NV_TPMA_NV_ORDERLY;
 
@@ -1500,31 +1267,17 @@ TSS2_RC CreateNVIndex( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TP
 TSS2_RC TestLocality( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
 {
     TSS2_RC rval = TPM2_RC_SUCCESS;
-    TSS2_SYS_CMD_AUTHS sessionsData;
     TPM2B_MAX_NV_BUFFER nvWriteData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut = { 1, };
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut = { 1, };
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths = {{
+        .sessionHandle = policySession->sessionHandle,
+        .sessionAttributes = TPMA_SESSION_CONTINUESESSION,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
 
     // Init write data.
     nvWriteData.size = 0;
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0]->sessionHandle = policySession->sessionHandle;
-    sessionsData.cmdAuths[0]->nonce.size = 0;
-    sessionsData.cmdAuths[0]->hmac.size = 0;
-
-    *(UINT8 *)( (void *)&( sessionsData.cmdAuths[0]->sessionAttributes ) ) = 0;
-     sessionsData.cmdAuths[0]->sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
 
     rval = SetLocality( sysContext, 2 );
     CheckPassed( rval );
@@ -1551,10 +1304,10 @@ TSS2_RC TestLocality( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
     CheckFailed( rval, TPM2_RC_POLICY_FAIL + TPM2_RC_S + TPM2_RC_1 );
 
     // Delete NV index
-    sessionsData.cmdAuths[0]->sessionHandle = TPM2_RS_PW;
-    sessionsData.cmdAuths[0]->nonce.size = 0;
-    sessionsData.cmdAuths[0]->nonce.buffer[0] = 0xa5;
-    sessionData.hmac.size = 0;
+    sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
+    sessionsData.auths[0].nonce.size = 0;
+    sessionsData.auths[0].nonce.buffer[0] = 0xa5;
+    sessionsData.auths[0].hmac.size = 0;
 
     // Now undefine the index.
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM,
@@ -1637,9 +1390,6 @@ TSS2_RC BuildPasswordPcrPolicy( TSS2_SYS_CONTEXT *sysContext, SESSION *policySes
 TSS2_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TPM2B_DIGEST *policyDigest )
 {
     TSS2_RC rval = TPM2_RC_SUCCESS;
-    TPMS_AUTH_COMMAND cmdAuth;
-    TPMS_AUTH_COMMAND *cmdSessionArray[1] = { &cmdAuth };
-    TSS2_SYS_CMD_AUTHS cmdAuthArray = { 1, &cmdSessionArray[0] };
     TPM2B_SENSITIVE_CREATE inSensitive;
     TPM2B_PUBLIC inPublic;
     TPM2B_DATA outsideInfo = {0,};
@@ -1653,10 +1403,11 @@ TSS2_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, T
 	TPM2B_DIGEST data;
     TPM2B_PRIVATE outPrivate;
 
-    cmdAuth.sessionHandle = TPM2_RS_PW;
-    cmdAuth.nonce.size = 0;
-    *( (UINT8 *)((void *)&cmdAuth.sessionAttributes ) ) = 0;
-    cmdAuth.hmac.size = 0;
+    TSS2L_SYS_AUTH_COMMAND cmdAuthArray = { .count = 1, .auths = {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     inSensitive.sensitive.userAuth.size = 0;
     inSensitive.sensitive.data.size = 0;
@@ -1689,7 +1440,7 @@ TSS2_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, T
             &creationTicket, &srkName, 0 );
     CheckPassed( rval );
 
-    cmdAuth.sessionHandle = TPM2_RS_PW;
+    cmdAuthArray.auths[0].sessionHandle = TPM2_RS_PW;
 
     inSensitive.sensitive.userAuth.size = 0;
     blobAuth.size = sizeof( passwordPCRTestPassword );
@@ -1730,15 +1481,11 @@ TSS2_RC AuthValueUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
 {
     TSS2_RC rval = TPM2_RC_SUCCESS;
     TPM2B_SENSITIVE_DATA outData;
-    TPMS_AUTH_COMMAND cmdAuth;
-    TPMS_AUTH_COMMAND *cmdSessionArray[1] = { &cmdAuth };
-    TSS2_SYS_CMD_AUTHS cmdAuthArray = { 1, &cmdSessionArray[0] };
-
-    cmdAuth.sessionHandle = policySession->sessionHandle;
-    cmdAuth.nonce.size = 0;
-    *( (UINT8 *)((void *)&cmdAuth.sessionAttributes ) ) = 0;
-    cmdAuth.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
-    cmdAuth.hmac.size = 0;
+    TSS2L_SYS_AUTH_COMMAND cmdAuthArray = { .count = 1, .auths = {{
+        .sessionHandle = policySession->sessionHandle,
+        .sessionAttributes = TPMA_SESSION_CONTINUESESSION,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     // Now try to unseal the blob without setting the HMAC.
     // This test should fail.
@@ -1762,7 +1509,7 @@ TSS2_RC AuthValueUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
     CheckPassed( rval );
 
     // Roll nonces for command.
-    RollNonces( policySession, &cmdAuth.nonce );
+    RollNonces( policySession, &cmdAuthArray.auths[0].nonce );
 
     // Now generate the HMAC.
     rval = ComputeCommandHmacs( sysContext,
@@ -1791,15 +1538,11 @@ TSS2_RC PasswordUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
 {
     TSS2_RC rval = TPM2_RC_SUCCESS;
     TPM2B_SENSITIVE_DATA outData;
-    TPMS_AUTH_COMMAND cmdAuth;
-    TPMS_AUTH_COMMAND *cmdSessionArray[1] = { &cmdAuth };
-    TSS2_SYS_CMD_AUTHS cmdAuthArray = { 1, &cmdSessionArray[0] };
-
-    cmdAuth.sessionHandle = policySession->sessionHandle;
-    cmdAuth.nonce.size = 0;
-    *( (UINT8 *)((void *)&cmdAuth.sessionAttributes ) ) = 0;
-    cmdAuth.sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
-    cmdAuth.hmac.size = 0;
+    TSS2L_SYS_AUTH_COMMAND cmdAuthArray = { .count = 1, .auths = {{
+        .sessionHandle = policySession->sessionHandle,
+        .sessionAttributes = TPMA_SESSION_CONTINUESESSION,
+        .nonce = {.size = 0},
+        .hmac = {.size = 0}}}};
 
     // Now try to unseal the blob without setting the password.
     // This test should fail.
@@ -1813,8 +1556,8 @@ TSS2_RC PasswordUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
     // Now try to unseal the blob after setting the password.
     // This test should pass.
     INIT_SIMPLE_TPM2B_SIZE( outData );
-    cmdAuth.hmac.size = sizeof( passwordPCRTestPassword );
-    memcpy( &cmdAuth.hmac.buffer, passwordPCRTestPassword, sizeof( passwordPCRTestPassword ) );
+    cmdAuthArray.auths[0].hmac.size = sizeof( passwordPCRTestPassword );
+    memcpy( &cmdAuthArray.auths[0].hmac.buffer, passwordPCRTestPassword, sizeof( passwordPCRTestPassword ) );
     rval = Tss2_Sys_Unseal( sysContext, blobHandle, &cmdAuthArray, &outData, 0 );
     CheckPassed( rval );
 
@@ -1919,15 +1662,11 @@ void TestHash()
     UINT32 rval;
     TPM2B_AUTH auth;
     TPMI_DH_OBJECT  sequenceHandle[MAX_TEST_SEQUENCES];
-    TPMS_AUTH_COMMAND sessionData, sessionData1;
-    TPMS_AUTH_RESPONSE sessionDataOut, sessionDataOut1;
-    TSS2_SYS_CMD_AUTHS sessionsData;
+    TSS2L_SYS_AUTH_COMMAND sessionsData;
     TPM2B_MAX_BUFFER dataToHash;
     TPM2B_DIGEST result;
     TPMT_TK_HASHCHECK validation;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
-    TPMS_AUTH_COMMAND *sessionDataArray[2];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[2];
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
     UINT8 memoryToHash[] =
     {
           0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -2002,17 +1741,6 @@ void TestHash()
             { 0xB3, 0xFD, 0x6A, 0xD2, 0x9F, 0xD0, 0x13, 0x52, 0xBA, 0xFC,
               0x8B, 0x22, 0xC9, 0x6D, 0x88, 0x42, 0xA3, 0x3C, 0xB0, 0xC9 };
 
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-    sessionDataArray[1] = &sessionData1;
-    sessionDataOutArray[1] = &sessionDataOut1;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
-
     DebugPrintf( NO_PREFIX, "\nHASH TESTS:\n" );
 
     auth.size = 2;
@@ -2021,13 +1749,11 @@ void TestHash()
     rval = Tss2_Sys_HashSequenceStart ( sysContext, 0, &auth, TPM2_ALG_SHA1, &sequenceHandle[0], 0 );
     CheckPassed( rval );
 
-    sessionData.sessionHandle = TPM2_RS_PW;
-    sessionData.nonce.size = 0;
-    sessionData.hmac = auth;
-    *((UINT8 *)((void *)&sessionData.sessionAttributes)) = 0;
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &sessionData;
+    sessionsData.auths[0].sessionHandle = TPM2_RS_PW;
+    sessionsData.auths[0].nonce.size = 0;
+    sessionsData.auths[0].hmac = auth;
+    sessionsData.auths[0].sessionAttributes = 0;
+    sessionsData.count = 1;
 
     dataToHash.size = TPM2_MAX_DIGEST_BUFFER;
     memcpy( &dataToHash.buffer[0], &memoryToHash[0], dataToHash.size );
@@ -2055,39 +1781,16 @@ void TestQuote()
     UINT8 qualDataString[] = { 0x00, 0xff, 0x55, 0xaa };
     TPMT_SIG_SCHEME inScheme;
     TPML_PCR_SELECTION  pcrSelection;
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
     TPM2B_ATTEST quoted;
     TPMT_SIGNATURE signature;
-
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=2, .buffer={0x00,0xff}}}}};
 
     DebugPrintf( NO_PREFIX, "\nQUOTE CONTROL TESTS:\n" );
-
-    // Init authHandle
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionData.nonce.size = 0;
-
-    // init hmac
-    sessionData.hmac.size = 2;
-    sessionData.hmac.buffer[0] = 0x00;
-    sessionData.hmac.buffer[1] = 0xff;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
 
     qualifyingData.size = sizeof( qualDataString );
     memcpy( &( qualifyingData.buffer[0] ), qualDataString, sizeof( qualDataString ) );
@@ -2105,9 +1808,6 @@ void TestQuote()
 
     // Now set the PCR you want
     pcrSelection.pcrSelections[0].pcrSelect[( PCR_17/8 )] = ( 1 << ( PCR_18 % 8) );
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &sessionData;
 
     // Test with wrong type of key.
     INIT_SIMPLE_TPM2B_SIZE( quoted );
@@ -2131,22 +1831,13 @@ void ProvisionOtherIndices()
     TPMI_SH_AUTH_SESSION otherIndicesPolicyAuthHandle;
     TPM2B_DIGEST  nvPolicyHash;
     TPM2B_AUTH  nvAuth;
-    TPMS_AUTH_COMMAND otherIndicesSessionData;
-    TPMS_AUTH_RESPONSE otherIndicesSessionDataOut;
-    TSS2_SYS_CMD_AUTHS otherIndicesSessionsData;
-    TSS2_SYS_RSP_AUTHS otherIndicesSessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE otherIndicesSessionsDataOut;
     TPM2B_NV_PUBLIC publicInfo;
-
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &otherIndicesSessionData;
-    sessionDataOutArray[0] = &otherIndicesSessionDataOut;
-
-    otherIndicesSessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    otherIndicesSessionsData.cmdAuths = &sessionDataArray[0];
-
-    otherIndicesSessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND otherIndicesSessionsData = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
 
     DebugPrintf( NO_PREFIX, "\nPROVISION OTHER NV INDICES:\n" );
 
@@ -2170,20 +1861,8 @@ void ProvisionOtherIndices()
     // Now save the policy digest from the first OR branch.
     DEBUG_PRINT_BUFFER( NO_PREFIX, &( nvPolicyHash.buffer[0] ), nvPolicyHash.size );
 
-    // 4.  CreateNvIndex
-    otherIndicesSessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    otherIndicesSessionData.nonce.size = 0;
-
-    // init hmac
-    otherIndicesSessionData.hmac.size = 0;
-
     // init nvAuth
     nvAuth.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&otherIndicesSessionData.sessionAttributes ) ) = 0;
 
     publicInfo.size = sizeof( TPMI_RH_NV_INDEX ) +
             sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
@@ -2192,7 +1871,7 @@ void ProvisionOtherIndices()
     publicInfo.nvPublic.nameAlg = TPM2_ALG_SHA1;
 
     // First zero out attributes.
-    *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
+    publicInfo.nvPublic.attributes = 0;
 
     // Now set the attributes.
     publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_AUTHREAD;
@@ -2205,9 +1884,6 @@ void ProvisionOtherIndices()
 
     publicInfo.nvPublic.authPolicy.size = 0;
     publicInfo.nvPublic.dataSize = NV_PS_INDEX_SIZE;
-
-    otherIndicesSessionsData.cmdAuthsCount = 1;
-    otherIndicesSessionsData.cmdAuths[0] = &otherIndicesSessionData;
 
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM2_RH_PLATFORM, &otherIndicesSessionsData,
             &nvAuth, &publicInfo, &otherIndicesSessionsDataOut );
@@ -2247,22 +1923,13 @@ void ProvisionNvAux()
     TPMI_SH_AUTH_SESSION nvAuxPolicyAuthHandle;
     TPM2B_DIGEST  nvPolicyHash;
     TPM2B_AUTH  nvAuth;
-    TPMS_AUTH_COMMAND nvAuxSessionData;
-    TPMS_AUTH_RESPONSE nvAuxSessionDataOut;
-    TSS2_SYS_CMD_AUTHS nvAuxSessionsData;
-    TSS2_SYS_RSP_AUTHS nvAuxSessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE nvAuxSessionsDataOut;
     TPM2B_NV_PUBLIC publicInfo;
-
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &nvAuxSessionData;
-    sessionDataOutArray[0] = &nvAuxSessionDataOut;
-
-    nvAuxSessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    nvAuxSessionsData.cmdAuths = &sessionDataArray[0];
-
-    nvAuxSessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND nvAuxSessionsData = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
 
     DebugPrintf( NO_PREFIX, "\nPROVISION NV AUX:\n" );
 
@@ -2286,23 +1953,8 @@ void ProvisionNvAux()
     // Now save the policy digest.
     DEBUG_PRINT_BUFFER( NO_PREFIX, &( nvPolicyHash.buffer[0] ), nvPolicyHash.size );
 
-    // 4.  CreateNvIndex
-    nvAuxSessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    nvAuxSessionData.nonce.size = 0;
-
-    // init hmac
-    nvAuxSessionData.hmac.size = 0;
-
     // init nvAuth
     nvAuth.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&nvAuxSessionData.sessionAttributes ) ) = 0;
-
-    nvAuxSessionsData.cmdAuthsCount = 1;
-    nvAuxSessionsData.cmdAuths[0] = &nvAuxSessionData;
 
     publicInfo.size = sizeof( TPMI_RH_NV_INDEX ) +
             sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
@@ -2350,16 +2002,15 @@ void TpmAuxWrite( int locality)
     for( i = 0; i < nvWriteData.size; i++ )
         nvWriteData.buffer[i] = 0xff - i;
 
-    nullSessionData.sessionHandle = nvAuxPolicyAuthHandle;
+    nullSessionsData.auths[0].sessionHandle = nvAuxPolicyAuthHandle;
 
     // Make sure that session terminates after NVWrite completes.
-    nullSessionData.sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
+    nullSessionsData.auths[0].sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     rval = SetLocality( sysContext, locality );
     CheckPassed( rval );
 
-    nullSessionsData.cmdAuthsCount = 1;
-    nullSessionsData.cmdAuths[0] = &nullSessionData;
+    nullSessionsData.count = 1;
 
     rval = Tss2_Sys_NV_Write( sysContext, INDEX_AUX, INDEX_AUX, &nullSessionsData, &nvWriteData, 0, &nullSessionsDataOut );
 
@@ -2394,7 +2045,7 @@ void TpmAuxReadWriteTest()
 
     DebugPrintf( NO_PREFIX, "TPM AUX READ/WRITE TEST\n" );
 
-    nullSessionData.sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
+    nullSessionsData.auths[0].sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     // Try writing it from all localities.  Only locality 3 should work.
     for( testLocality = 0; testLocality < 5; testLocality++ )
@@ -2402,9 +2053,7 @@ void TpmAuxReadWriteTest()
         TpmAuxWrite( testLocality );
     }
 
-    nullSessionData.sessionHandle = TPM2_RS_PW;
-
-    nullSessionsData.cmdAuths[0] = &nullSessionData;
+    nullSessionsData.auths[0].sessionHandle = TPM2_RS_PW;
 
     // Try reading it from all localities.  They all should work.
     for( testLocality = 0; testLocality < 5; testLocality++ )
@@ -2428,16 +2077,13 @@ void TpmOtherIndicesReadWriteTest()
     int i;
     TPM2B_MAX_NV_BUFFER nvData;
 
-    nullSessionData.sessionHandle = TPM2_RS_PW;
+    nullSessionsData.auths[0].sessionHandle = TPM2_RS_PW;
 
     DebugPrintf( NO_PREFIX, "TPM OTHER READ/WRITE TEST\n" );
 
     nvWriteData.size = 4;
     for( i = 0; i < nvWriteData.size; i++ )
         nvWriteData.buffer[i] = 0xff - i;
-
-    nullSessionsData.cmdAuthsCount = 1;
-    nullSessionsData.cmdAuths[0] = &nullSessionData;
 
     rval = Tss2_Sys_NV_Write( sysContext, INDEX_LCP_SUP, INDEX_LCP_SUP, &nullSessionsData, &nvWriteData, 0, &nullSessionsDataOut );
     CheckPassed( rval );
@@ -2490,44 +2136,21 @@ void TestPcrAllocate()
 {
     UINT32 rval;
     TPML_PCR_SELECTION  pcrSelection;
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
     TPMI_YES_NO allocationSuccess;
     UINT32 maxPcr;
     UINT32 sizeNeeded;
     UINT32 sizeAvailable;
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
 
     DebugPrintf( NO_PREFIX, "\nPCR ALLOCATE TEST  :\n" );
 
-    // Init authHandle
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionData.nonce.size = 0;
-
-    // init hmac
-    sessionData.hmac.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-
     pcrSelection.count = 0;
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &sessionData;
 
     rval = Tss2_Sys_PCR_Allocate( sysContext, TPM2_RH_PLATFORM, &sessionsData, &pcrSelection,
             &allocationSuccess, &maxPcr, &sizeNeeded, &sizeAvailable, &sessionsDataOut);
@@ -2557,26 +2180,18 @@ void TestPcrAllocate()
 void TestUnseal()
 {
     UINT32 rval;
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
     TPM2B_SENSITIVE_CREATE  inSensitive;
     TPML_PCR_SELECTION      creationPCR;
     TPM2B_DATA              outsideInfo;
     TPM2B_PUBLIC            inPublic;
     TPM2_HANDLE loadedObjectHandle;
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
-
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionsDataOut.rspAuthsCount = 1;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=2, .buffer={0x00,0xff}}}}};
 
     TPM2B_PRIVATE outPrivate;
     TPM2B_PUBLIC outPublic;
@@ -2591,18 +2206,6 @@ void TestUnseal()
     const char sensitiveData[] = "this is sensitive";
 
     DebugPrintf( NO_PREFIX, "\nUNSEAL TEST  :\n" );
-
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionData.nonce.size = 0;
-
-    sessionData.hmac.size = 2;
-    sessionData.hmac.buffer[0] = 0x00;
-    sessionData.hmac.buffer[1] = 0xff;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
 
     inSensitive.sensitive.userAuth.size = sizeof( authStr ) - 1;
     memcpy( &( inSensitive.sensitive.userAuth.buffer[0] ), authStr, sizeof( authStr ) - 1 );
@@ -2628,9 +2231,6 @@ void TestUnseal()
 
     outsideInfo.size = 0;
 
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0]  = &sessionData;
-
     outPublic.size = 0;
     creationData.size = 0;
     INIT_SIMPLE_TPM2B_SIZE( creationHash );
@@ -2654,8 +2254,8 @@ void TestUnseal()
             &loadedObjectHandle, &name, &sessionsDataOut);
     CheckPassed( rval );
 
-    sessionData.hmac.size = sizeof( authStr ) - 1;
-    memcpy( &( sessionData.hmac.buffer[0] ), authStr, sizeof( authStr ) - 1 );
+    sessionsData.auths[0].hmac.size = sizeof( authStr ) - 1;
+    memcpy( &( sessionsData.auths[0].hmac.buffer[0] ), authStr, sizeof( authStr ) - 1 );
 
     INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_Unseal( sysContext, loadedObjectHandle, &sessionsData, &outData, &sessionsDataOut );
@@ -2670,37 +2270,16 @@ void CreatePasswordTestNV( TPMI_RH_NV_INDEX nvIndex, char * password )
 {
     UINT32 rval;
     int i;
-    TPMS_AUTH_COMMAND sessionData;
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TSS2_SYS_CMD_AUTHS sessionsData;
-    TSS2_SYS_RSP_AUTHS sessionsDataOut;
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
     TPM2B_NV_PUBLIC publicInfo;
     TPM2B_AUTH  nvAuth;
 
-    TPMS_AUTH_COMMAND *sessionDataArray[1];
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1];
 
-    sessionDataArray[0] = &sessionData;
-    sessionDataOutArray[0] = &sessionDataOut;
-
-    sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    sessionsData.cmdAuths = &sessionDataArray[0];
-
-    sessionData.sessionHandle = TPM2_RS_PW;
-
-    // Init nonce.
-    sessionData.nonce.size = 0;
-
-    // init hmac
-    sessionData.hmac.size = 0;
-
-    // Init session attributes
-    *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-
-    sessionsDataOut.rspAuthsCount = 1;
-
-    sessionsData.cmdAuthsCount = 1;
-    sessionsData.cmdAuths[0] = &sessionData;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
 
     nvAuth.size = strlen( password );
     for( i = 0; i < nvAuth.size; i++ ) {
@@ -2737,25 +2316,16 @@ void PasswordTest()
     UINT32 rval;
     int i;
 
-    // Authorization structure for command.
-    TPMS_AUTH_COMMAND sessionData;
-
-    // Authorization structure for response.
-    TPMS_AUTH_RESPONSE sessionDataOut;
-
-    // Create and init authorization area for command:
-    // only 1 authorization area.
-    TPMS_AUTH_COMMAND *sessionDataArray[1] = { &sessionData };
-
-    // Create authorization area for response:
-    // only 1 authorization area.
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1] = { &sessionDataOut };
+    // Authorization array for response.
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
 
     // Authorization array for command (only has one auth structure).
-    TSS2_SYS_CMD_AUTHS sessionsData = { 1, &sessionDataArray[0] };
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
 
-    // Authorization array for response (only has one auth structure).
-    TSS2_SYS_RSP_AUTHS sessionsDataOut = { 1, &sessionDataOutArray[0] };
     TPM2B_MAX_NV_BUFFER nvWriteData;
 
     DebugPrintf( NO_PREFIX, "\nPASSWORD TESTS:\n" );
@@ -2765,24 +2335,10 @@ void PasswordTest()
     // "test password".
     CreatePasswordTestNV( TPM20_INDEX_PASSWORD_TEST, password );
 
-    //
-    // Initialize the command authorization area.
-    //
-
-    // Init sessionHandle, nonce, session
-    // attributes, and hmac (password).
-    sessionData.sessionHandle = TPM2_RS_PW;
-    // Set zero sized nonce.
-    sessionData.nonce.size = 0;
-    // sessionAttributes is a bit field.  To initialize
-    // it to 0, cast to a pointer to UINT8 and
-    // write 0 to that pointer.
-    *( (UINT8 *)&sessionData.sessionAttributes ) = 0;
-
     // Init password (HMAC field in authorization structure).
-    sessionData.hmac.size = strlen( password );
-    memcpy( &( sessionData.hmac.buffer[0] ),
-            &( password[0] ), sessionData.hmac.size );
+    sessionsData.auths[0].hmac.size = strlen( password );
+    memcpy( &( sessionsData.auths[0].hmac.buffer[0] ),
+            &( password[0] ), sessionsData.auths[0].hmac.size );
 
     // Initialize write data.
     nvWriteData.size = 4;
@@ -2801,7 +2357,7 @@ void PasswordTest()
     CheckPassed( rval );
 
     // Alter the password so it's incorrect.
-    sessionData.hmac.buffer[4] = 0xff;
+    sessionsData.auths[0].hmac.buffer[4] = 0xff;
     rval = Tss2_Sys_NV_Write( sysContext,
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
@@ -2815,7 +2371,7 @@ void PasswordTest()
 
     // Change hmac to null one, since null auth is
     // used to undefine the index.
-    sessionData.hmac.size = 0;
+    sessionsData.auths[0].hmac.size = 0;
 
     // Now undefine the index.
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM2_RH_PLATFORM,
@@ -2837,17 +2393,17 @@ void SimplePolicyTest()
     int i;
     TPM2B_ENCRYPTED_SECRET encryptedSalt;
     TPMT_SYM_DEF symmetric;
-    TPMA_SESSION sessionAttributes;
-
-    // Command authorization area: one password session.
-    TPMS_AUTH_COMMAND nvCmdAuth = { TPM2_RS_PW, };
-    TPMS_AUTH_COMMAND *nvCmdAuthArray[1] = { &nvCmdAuth };
-    TSS2_SYS_CMD_AUTHS nvCmdAuths = { 1, &nvCmdAuthArray[0] };
 
     // Response authorization area.
-    TPMS_AUTH_RESPONSE nvRspAuth;
-    TPMS_AUTH_RESPONSE *nvRspAuthArray[1] = { &nvRspAuth };
-    TSS2_SYS_RSP_AUTHS nvRspAuths = { 1, &nvRspAuthArray[0] };
+    TSS2L_SYS_AUTH_RESPONSE nvRspAuths;
+
+    // Command authorization area: one password session.
+    TSS2L_SYS_AUTH_COMMAND nvCmdAuths = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
+
     TPM2_ALG_ID sessionAlg = TPM2_ALG_SHA256;
     TPM2B_NONCE nonceCaller;
 
@@ -2972,15 +2528,14 @@ void SimplePolicyTest()
     CheckPassed( rval );
 
     // Configure command authorization area, except for HMAC.
-    nvCmdAuths.cmdAuths[0]->sessionHandle = nvSession->sessionHandle;
-    nvCmdAuths.cmdAuths[0]->nonce.size = 1;
-    nvCmdAuths.cmdAuths[0]->nonce.buffer[0] = 0xa5;
-    *( (UINT8 *)((void *)&sessionAttributes ) ) = 0;
-    nvCmdAuths.cmdAuths[0]->sessionAttributes = sessionAttributes;
-    nvCmdAuths.cmdAuths[0]->sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
+    nvCmdAuths.auths[0].sessionHandle = nvSession->sessionHandle;
+    nvCmdAuths.auths[0].nonce.size = 1;
+    nvCmdAuths.auths[0].nonce.buffer[0] = 0xa5;
+    nvCmdAuths.auths[0].sessionAttributes = 0;
+    nvCmdAuths.auths[0].sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
 
     // Roll nonces for command
-    RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
+    RollNonces( nvSession, &nvCmdAuths.auths[0].nonce );
 
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
@@ -3000,7 +2555,7 @@ void SimplePolicyTest()
     CheckPassed( sessionCmdRval );
 
     // Roll nonces for response
-    RollNonces( nvSession, &nvRspAuths.rspAuths[0]->nonce );
+    RollNonces( nvSession, &nvRspAuths.auths[0].nonce );
 
     if( sessionCmdRval == TPM2_RC_SUCCESS )
     {
@@ -3022,10 +2577,10 @@ void SimplePolicyTest()
     CheckPassed( rval );
 
     // Roll nonces for command
-    RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
+    RollNonces( nvSession, &nvCmdAuths.auths[0].nonce );
 
     // End the session after next command.
-    nvCmdAuths.cmdAuths[0]->sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
+    nvCmdAuths.auths[0].sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
@@ -3047,7 +2602,7 @@ void SimplePolicyTest()
     CheckPassed( sessionCmdRval );
 
     // Roll nonces for response
-    RollNonces( nvSession, &nvRspAuths.rspAuths[0]->nonce );
+    RollNonces( nvSession, &nvRspAuths.auths[0].nonce );
 
     if( sessionCmdRval == TPM2_RC_SUCCESS )
     {
@@ -3074,9 +2629,9 @@ void SimplePolicyTest()
     //
 
     // Setup authorization for undefining the NV index.
-    nvCmdAuths.cmdAuths[0]->sessionHandle = TPM2_RS_PW;
-    nvCmdAuths.cmdAuths[0]->nonce.size = 0;
-    nvCmdAuths.cmdAuths[0]->hmac.size = 0;
+    nvCmdAuths.auths[0].sessionHandle = TPM2_RS_PW;
+    nvCmdAuths.auths[0].nonce.size = 0;
+    nvCmdAuths.auths[0].hmac.size = 0;
 
     // Undefine the NV index.
     rval = Tss2_Sys_NV_UndefineSpace( sysContext,
@@ -3105,15 +2660,16 @@ void SimpleHmacTest()
     TPMT_SYM_DEF symmetric;
     TPMA_SESSION sessionAttributes;
 
-    // Command authorization area: one password session.
-    TPMS_AUTH_COMMAND nvCmdAuth = { TPM2_RS_PW, };
-    TPMS_AUTH_COMMAND *nvCmdAuthArray[1] = { &nvCmdAuth };
-    TSS2_SYS_CMD_AUTHS nvCmdAuths = { 1, &nvCmdAuthArray[0] };
-
     // Response authorization area.
-    TPMS_AUTH_RESPONSE nvRspAuth;
-    TPMS_AUTH_RESPONSE *nvRspAuthArray[1] = { &nvRspAuth };
-    TSS2_SYS_RSP_AUTHS nvRspAuths = { 1, &nvRspAuthArray[0] };
+    TSS2L_SYS_AUTH_RESPONSE nvRspAuths;
+
+    // Command authorization area: one password session.
+    TSS2L_SYS_AUTH_COMMAND nvCmdAuths = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
+
     TPM2B_NONCE nonceCaller;
 
     nonceCaller.size = 0;
@@ -3203,15 +2759,15 @@ void SimpleHmacTest()
     CheckPassed( rval );
 
     // Configure command authorization area, except for HMAC.
-    nvCmdAuths.cmdAuths[0]->sessionHandle = nvSession->sessionHandle;
-    nvCmdAuths.cmdAuths[0]->nonce.size = 1;
-    nvCmdAuths.cmdAuths[0]->nonce.buffer[0] = 0xa5;
+    nvCmdAuths.auths[0].sessionHandle = nvSession->sessionHandle;
+    nvCmdAuths.auths[0].nonce.size = 1;
+    nvCmdAuths.auths[0].nonce.buffer[0] = 0xa5;
     *( (UINT8 *)(&sessionAttributes ) ) = 0;
-    nvCmdAuths.cmdAuths[0]->sessionAttributes = sessionAttributes;
-    nvCmdAuths.cmdAuths[0]->sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
+    nvCmdAuths.auths[0].sessionAttributes = 0;
+    nvCmdAuths.auths[0].sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
 
     // Roll nonces for command
-    RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
+    RollNonces( nvSession, &nvCmdAuths.auths[0].nonce );
 
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
@@ -3231,7 +2787,7 @@ void SimpleHmacTest()
     CheckPassed( sessionCmdRval );
 
     // Roll nonces for response
-    RollNonces( nvSession, &nvRspAuths.rspAuths[0]->nonce );
+    RollNonces( nvSession, &nvRspAuths.auths[0].nonce );
 
     if( sessionCmdRval == TPM2_RC_SUCCESS )
     {
@@ -3250,10 +2806,10 @@ void SimpleHmacTest()
     CheckPassed( rval );
 
     // Roll nonces for command
-    RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
+    RollNonces( nvSession, &nvCmdAuths.auths[0].nonce );
 
     // End the session after next command.
-    nvCmdAuths.cmdAuths[0]->sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
+    nvCmdAuths.auths[0].sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
@@ -3275,7 +2831,7 @@ void SimpleHmacTest()
     CheckPassed( sessionCmdRval );
 
     // Roll nonces for response
-    RollNonces( nvSession, &nvRspAuths.rspAuths[0]->nonce );
+    RollNonces( nvSession, &nvRspAuths.auths[0].nonce );
 
     if( sessionCmdRval == TPM2_RC_SUCCESS )
     {
@@ -3302,9 +2858,9 @@ void SimpleHmacTest()
     //
 
     // Setup authorization for undefining the NV index.
-    nvCmdAuths.cmdAuths[0]->sessionHandle = TPM2_RS_PW;
-    nvCmdAuths.cmdAuths[0]->nonce.size = 0;
-    nvCmdAuths.cmdAuths[0]->hmac.size = 0;
+    nvCmdAuths.auths[0].sessionHandle = TPM2_RS_PW;
+    nvCmdAuths.auths[0].nonce.size = 0;
+    nvCmdAuths.auths[0].hmac.size = 0;
 
     // Undefine the NV index.
     rval = Tss2_Sys_NV_UndefineSpace( sysContext,
@@ -3338,21 +2894,20 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     int i;
     TPM2B_ENCRYPTED_SECRET encryptedSalt;
     TPMT_SYM_DEF symmetric;
-    TPMA_SESSION sessionAttributes;
     TPM2_SE tpmSe;
     char *testString;
     char testStringHmac[] = "HMAC";
     char testStringPolicy[] = "POLICY";
 
-    // Command authorization area: one password session.
-    TPMS_AUTH_COMMAND nvCmdAuth = { TPM2_RS_PW, };
-    TPMS_AUTH_COMMAND *nvCmdAuthArray[1] = {&nvCmdAuth};
-    TSS2_SYS_CMD_AUTHS nvCmdAuths = { 1, &nvCmdAuthArray[0] };
-
     // Response authorization area.
-    TPMS_AUTH_RESPONSE nvRspAuth;
-    TPMS_AUTH_RESPONSE *nvRspAuthArray[1] = { &nvRspAuth };
-    TSS2_SYS_RSP_AUTHS nvRspAuths = { 1, &nvRspAuthArray[0] };
+    TSS2L_SYS_AUTH_RESPONSE nvRspAuths;
+
+    // Command authorization area: one password session.
+    TSS2L_SYS_AUTH_COMMAND nvCmdAuths = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
 
     TSS2_SYS_CONTEXT *simpleTestContext;
     TPM2B_NONCE nonceCaller;
@@ -3529,16 +3084,15 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     CheckPassed( rval );
 
     // Configure command authorization area, except for HMAC.
-    nvCmdAuths.cmdAuths[0]->sessionHandle =
+    nvCmdAuths.auths[0].sessionHandle =
             nvSession->sessionHandle;
-    nvCmdAuths.cmdAuths[0]->nonce.size = 1;
-    nvCmdAuths.cmdAuths[0]->nonce.buffer[0] = 0xa5;
-    *( (UINT8 *)(&sessionAttributes ) ) = 0;
-    nvCmdAuths.cmdAuths[0]->sessionAttributes = sessionAttributes;
-    nvCmdAuths.cmdAuths[0]->sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
+    nvCmdAuths.auths[0].nonce.size = 1;
+    nvCmdAuths.auths[0].nonce.buffer[0] = 0xa5;
+    nvCmdAuths.auths[0].sessionAttributes = 0;
+    nvCmdAuths.auths[0].sessionAttributes |= TPMA_SESSION_CONTINUESESSION;
 
     // Roll nonces for command
-    RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
+    RollNonces( nvSession, &nvCmdAuths.auths[0].nonce );
 
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
@@ -3557,7 +3111,7 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     CheckPassed( sessionCmdRval );
 
     // Roll nonces for response
-    RollNonces( nvSession, &nvRspAuths.rspAuths[0]->nonce );
+    RollNonces( nvSession, &nvRspAuths.auths[0].nonce );
 
     if( sessionCmdRval == TPM2_RC_SUCCESS )
     {
@@ -3585,10 +3139,10 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     CheckPassed( rval );
 
     // Roll nonces for command
-    RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
+    RollNonces( nvSession, &nvCmdAuths.auths[0].nonce );
 
     // End the session after next command.
-    nvCmdAuths.cmdAuths[0]->sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
+    nvCmdAuths.auths[0].sessionAttributes &= ~TPMA_SESSION_CONTINUESESSION;
 
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
@@ -3610,7 +3164,7 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     CheckPassed( sessionCmdRval );
 
     // Roll nonces for response
-    RollNonces( nvSession, &nvRspAuths.rspAuths[0]->nonce );
+    RollNonces( nvSession, &nvRspAuths.auths[0].nonce );
 
     if( sessionCmdRval == TPM2_RC_SUCCESS )
     {
@@ -3637,9 +3191,9 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     //
 
     // Setup authorization for undefining the NV index.
-    nvCmdAuths.cmdAuths[0]->sessionHandle = TPM2_RS_PW;
-    nvCmdAuths.cmdAuths[0]->nonce.size = 0;
-    nvCmdAuths.cmdAuths[0]->hmac.size = 0;
+    nvCmdAuths.auths[0].sessionHandle = TPM2_RS_PW;
+    nvCmdAuths.auths[0].nonce.size = 0;
+    nvCmdAuths.auths[0].hmac.size = 0;
 
     // Undefine the NV index.
     rval = Tss2_Sys_NV_UndefineSpace( simpleTestContext,
@@ -3678,20 +3232,16 @@ void TestEncryptDecryptSession()
     TPM2B_DIGEST        authPolicy;
     TPMA_NV             nvAttributes;
     int                 i;
-    TPMA_SESSION        sessionAttributes;
     TPM2B_NONCE         nonceCaller;
 
     nonceCaller.size = 0;
 
-    // Authorization structure for undefine command.
-    TPMS_AUTH_COMMAND nvUndefineAuth;
-
-    // Create and init authorization area for undefine command:
-    // only 1 authorization area.
-    TPMS_AUTH_COMMAND *nvUndefineAuthArray[1] = { &nvUndefineAuth };
-
     // Authorization array for command (only has one auth structure).
-    TSS2_SYS_CMD_AUTHS nvUndefineAuths = { 1, &nvUndefineAuthArray[0] };
+    TSS2L_SYS_AUTH_COMMAND nvUndefineAuths = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW,
+        .sessionAttributes = 0,
+        .nonce={.size=0},
+        .hmac={.size=0}}}};
 
     DebugPrintf( NO_PREFIX, "\n\nDECRYPT/ENCRYPT SESSION TESTS:\n" );
 
@@ -3720,39 +3270,12 @@ void TestEncryptDecryptSession()
     //
     for( i = 0; i < 2; i++ )
     {
-        // Authorization structure for NV
-        // read/write commands.
-        TPMS_AUTH_COMMAND nvRdWrCmdAuth;
-
-        // Authorization structure for
-        // encrypt/decrypt session.
-        TPMS_AUTH_COMMAND decryptEncryptSessionCmdAuth;
-
-        // Create and init authorization area for
-        // NV read/write commands:
-        // 2 authorization areas.
-        TPMS_AUTH_COMMAND *nvRdWrCmdAuthArray[2] =
-                { &nvRdWrCmdAuth, &decryptEncryptSessionCmdAuth };
-
         // Authorization array for commands
         // (has two auth structures).
-        TSS2_SYS_CMD_AUTHS nvRdWrCmdAuths =
-                { 2, &nvRdWrCmdAuthArray[0] };
+        TSS2L_SYS_AUTH_COMMAND nvRdWrCmdAuths = { .count = 2 };
 
-        // Authorization structure for NV read/write responses.
-        TPMS_AUTH_RESPONSE nvRdWrRspAuth;
-        // Authorization structure for decrypt/encrypt
-        // session responses.
-        TPMS_AUTH_RESPONSE decryptEncryptSessionRspAuth;
-
-        // Create and init authorization area for NV
-        // read/write responses:  2 authorization areas.
-        TPMS_AUTH_RESPONSE *nvRdWrRspAuthArray[2] =
-                { &nvRdWrRspAuth, &decryptEncryptSessionRspAuth };
         // Authorization array for responses
-        // (has two auth structures).
-        TSS2_SYS_RSP_AUTHS nvRdWrRspAuths =
-                { 2, &nvRdWrRspAuthArray[0] };
+        TSS2L_SYS_AUTH_RESPONSE nvRdWrRspAuths;
 
         // Setup session parameters.
         if( i == 0 )
@@ -3794,25 +3317,23 @@ void TestEncryptDecryptSession()
         CheckPassed( rval );
 
         // Set up password authorization session structure.
-        nvRdWrCmdAuth.sessionHandle = TPM2_RS_PW;
-        nvRdWrCmdAuth.nonce.size = 0;
-        *( (UINT8 *)((void *)&nvRdWrCmdAuth.sessionAttributes ) ) = 0;
-        nvRdWrCmdAuth.hmac.size = nvAuth.size;
-        memcpy( (void *)&nvRdWrCmdAuth.hmac.buffer[0],
+        nvRdWrCmdAuths.auths[0].sessionHandle = TPM2_RS_PW;
+        nvRdWrCmdAuths.auths[0].nonce.size = 0;
+        nvRdWrCmdAuths.auths[0].sessionAttributes = 0;
+        nvRdWrCmdAuths.auths[0].hmac.size = nvAuth.size;
+        memcpy( (void *)&nvRdWrCmdAuths.auths[0].hmac.buffer[0],
                 (void *)&nvAuth.buffer[0],
-                nvRdWrCmdAuth.hmac.size );
+                nvRdWrCmdAuths.auths[0].hmac.size );
 
         // Set up encrypt/decrypt session structure.
-        decryptEncryptSessionCmdAuth.sessionHandle =
+        nvRdWrCmdAuths.auths[1].sessionHandle =
                 encryptDecryptSession->sessionHandle;
-        decryptEncryptSessionCmdAuth.nonce.size = 0;
-        *( (UINT8 *)((void *)&sessionAttributes ) ) = 0;
-        decryptEncryptSessionCmdAuth.sessionAttributes =
-                sessionAttributes;
-        decryptEncryptSessionCmdAuth.sessionAttributes |= 
+        nvRdWrCmdAuths.auths[1].nonce.size = 0;
+        nvRdWrCmdAuths.auths[1].sessionAttributes = 0;
+        nvRdWrCmdAuths.auths[1].sessionAttributes |= 
                 TPMA_SESSION_CONTINUESESSION;
-        decryptEncryptSessionCmdAuth.sessionAttributes |= TPMA_SESSION_DECRYPT;
-        decryptEncryptSessionCmdAuth.hmac.size = 0;
+        nvRdWrCmdAuths.auths[1].sessionAttributes |= TPMA_SESSION_DECRYPT;
+        nvRdWrCmdAuths.auths[1].hmac.size = 0;
 
         rval = Tss2_Sys_SetCmdAuths( sysContext, &nvRdWrCmdAuths );
         CheckPassed( rval );
@@ -3836,7 +3357,7 @@ void TestEncryptDecryptSession()
 
         // Roll nonces for command.
         RollNonces( encryptDecryptSession,
-                &decryptEncryptSessionCmdAuth.nonce );
+                &nvRdWrCmdAuths.auths[1].nonce );
 
         // Encrypt write data.
         rval = EncryptCommandParam(encryptDecryptSession,
@@ -3862,29 +3383,29 @@ void TestEncryptDecryptSession()
 
         // Roll the nonces for response
         RollNonces( encryptDecryptSession,
-                &nvRdWrRspAuths.rspAuths[1]->nonce );
+                &nvRdWrRspAuths.auths[1].nonce );
 
 
         // Don't need nonces for anything else, so roll
         // the nonces for next command.
         RollNonces( encryptDecryptSession,
-                &decryptEncryptSessionCmdAuth.nonce );
+                &nvRdWrCmdAuths.auths[1].nonce );
 
         // Now read the data without encrypt set.
-        nvRdWrCmdAuths.cmdAuthsCount = 1;
-        nvRdWrRspAuths.rspAuthsCount = 1;
+        nvRdWrCmdAuths.count = 1;
+        nvRdWrRspAuths.count = 1;
         INIT_SIMPLE_TPM2B_SIZE( readData );
         rval = Tss2_Sys_NV_Read( sysContext, TPM20_INDEX_TEST1,
                 TPM20_INDEX_TEST1, &nvRdWrCmdAuths,
                 sizeof( writeDataString ), 0, &readData,
                 &nvRdWrRspAuths );
         CheckPassed( rval );
-        nvRdWrCmdAuths.cmdAuthsCount = 2;
-        nvRdWrRspAuths.rspAuthsCount = 2;
+        nvRdWrCmdAuths.count = 2;
+        nvRdWrRspAuths.count = 2;
 
         // Roll the nonces for response
         RollNonces( encryptDecryptSession,
-                &nvRdWrRspAuths.rspAuths[1]->nonce );
+                &nvRdWrRspAuths.auths[1].nonce );
 
         // Check that write and read data are equal.  This
         // verifies that the decrypt session was setup correctly.
@@ -3908,11 +3429,11 @@ void TestEncryptDecryptSession()
 
         // Roll the nonces for next command.
         RollNonces( encryptDecryptSession,
-                &decryptEncryptSessionCmdAuth.nonce );
+                &nvRdWrCmdAuths.auths[1].nonce );
 
-        decryptEncryptSessionCmdAuth.sessionAttributes &= ~TPMA_SESSION_DECRYPT;
-        decryptEncryptSessionCmdAuth.sessionAttributes |= TPMA_SESSION_ENCRYPT;
-        decryptEncryptSessionCmdAuth.sessionAttributes |= 
+        nvRdWrCmdAuths.auths[1].sessionAttributes &= ~TPMA_SESSION_DECRYPT;
+        nvRdWrCmdAuths.auths[1].sessionAttributes |= TPMA_SESSION_ENCRYPT;
+        nvRdWrCmdAuths.auths[1].sessionAttributes |= 
                 TPMA_SESSION_CONTINUESESSION;
 
         rval = Tss2_Sys_SetCmdAuths( sysContext, &nvRdWrCmdAuths );
@@ -3933,7 +3454,7 @@ void TestEncryptDecryptSession()
 
         // Roll the nonces for response
         RollNonces( encryptDecryptSession,
-                &nvRdWrRspAuths.rspAuths[1]->nonce );
+                &nvRdWrRspAuths.auths[1].nonce );
 
         // Decrypt read data.
         encryptedReadData.size = encryptParamSize;
@@ -3947,7 +3468,7 @@ void TestEncryptDecryptSession()
 
         // Roll the nonces.
         RollNonces( encryptDecryptSession,
-                &nvRdWrRspAuths.rspAuths[1]->nonce );
+                &nvRdWrRspAuths.auths[1].nonce );
 
         rval = Tss2_Sys_SetEncryptParam( sysContext,
                 (uint8_t)decryptedReadData.size,
@@ -3977,12 +3498,6 @@ void TestEncryptDecryptSession()
         rval = EndAuthSession( encryptDecryptSession );
         CheckPassed( rval );
     }
-
-    // Set authorization for NV undefine command.
-    nvUndefineAuth.sessionHandle = TPM2_RS_PW;
-    nvUndefineAuth.nonce.size = 0;
-    *( (UINT8 *)((void *)&nvUndefineAuth.sessionAttributes ) ) = 0;
-    nvUndefineAuth.hmac.size = 0;
 
     // Undefine NV index.
     rval = Tss2_Sys_NV_UndefineSpace( sysContext,
@@ -4229,12 +3744,9 @@ void GetSetEncryptParamTests()
     TPMA_NV nvAttributes;
     TPM2B_AUTH  nvAuth;
 
-    TPMS_AUTH_COMMAND sessionData = { TPM2_RS_PW, };
-    TPMS_AUTH_RESPONSE sessionDataOut;
-    TPMS_AUTH_COMMAND *sessionDataArray[1] = { &sessionData };
-    TPMS_AUTH_RESPONSE *sessionDataOutArray[1] = { &sessionDataOut };
-    TSS2_SYS_CMD_AUTHS sessionsData = { 1, &sessionDataArray[0] };
-    TSS2_SYS_RSP_AUTHS sessionsDataOut = { 1, &sessionDataOutArray[0] };
+    TSS2L_SYS_AUTH_RESPONSE sessionsDataOut;
+    TSS2L_SYS_AUTH_COMMAND sessionsData = { .count = 1, .auths= {{
+        .sessionHandle = TPM2_RS_PW }}};
 
     TPM2B_MAX_NV_BUFFER nvReadData;
     const uint8_t 		*cpBuffer;
@@ -4408,9 +3920,9 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         return 1;
     }
 
-    nullSessionsDataOut.rspAuthsCount = 1;
-    nullSessionsDataOut.rspAuths[0]->nonce = nullSessionNonceOut;
-    nullSessionsDataOut.rspAuths[0]->hmac = nullSessionHmac;
+    nullSessionsDataOut.count = 1;
+    nullSessionsDataOut.auths[0].nonce = nullSessionNonceOut;
+    nullSessionsDataOut.auths[0].hmac = nullSessionHmac;
     nullSessionNonceOut.size = 0;
     nullSessionNonce.size = 0;
 
@@ -4423,7 +3935,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 
     InitEntities();
 
-    InitNullSession( &nullSessionData);
+    InitNullSession( &nullSessionsData.auths[0]);
 
     SysFinalizeTests();
 


### PR DESCRIPTION
Since the last iteration of the specification there is just a struct
with an array directly embedded.
This is a large change, but removes a lot of complexity.

Note that this applies on top of #627 and did not make sense separately...