### PR TITLE
MU: Add missing marshaling functions

### DIFF
--- a/include/sapi/tss2_mu.h
+++ b/include/sapi/tss2_mu.h
@@ -1848,6 +1848,75 @@ Tss2_MU_TPMT_TK_HASHCHECK_Unmarshal(
     size_t        *offset,
     TPMT_TK_HASHCHECK *dest);
 
+TSS2_RC Tss2_MU_TPM2_HANDLE_Marshal(
+    TPM2_HANDLE     in,
+    uint8_t         *buffer,
+    size_t          size,
+    size_t          *offset);
+
+TSS2_RC
+Tss2_MU_TPM2_HANDLE_Unmarshal(
+    uint8_t const   buffer[],
+    size_t          size,
+    size_t          *offset,
+    TPM2_HANDLE     *out);
+
+TSS2_RC
+Tss2_MU_TPMI_ALG_HASH_Marshal(
+    TPMI_ALG_HASH   in,
+    uint8_t         *buffer,
+    size_t          size,
+    size_t          *offset);
+
+TSS2_RC
+Tss2_MU_TPMI_ALG_HASH_Unmarshal(
+    uint8_t const   buffer[],
+    size_t          size,
+    size_t          *offset,
+    TPMI_ALG_HASH   *out);
+
+TSS2_RC
+Tss2_MU_BYTE_Marshal(
+    BYTE            in,
+    uint8_t         *buffer,
+    size_t          size,
+    size_t          *offset);
+
+TSS2_RC
+Tss2_MU_BYTE_Unmarshal(
+    uint8_t const   buffer[],
+    size_t          size,
+    size_t          *offset,
+    BYTE            *out);
+
+TSS2_RC
+Tss2_MU_TPM2_SE_Marshal(
+    TPM2_SE         in,
+    uint8_t         *buffer,
+    size_t          size,
+    size_t          *offset);
+
+TSS2_RC
+Tss2_MU_TPM2_SE_Unmarshal(
+    uint8_t const   buffer[],
+    size_t          size,
+    size_t          *offset,
+    TPM2_SE         *out);
+
+TSS2_RC
+Tss2_MU_TPMS_EMPTY_Marshal(
+    TPMS_EMPTY const *in,
+    uint8_t         *buffer,
+    size_t          size,
+    size_t          *offset);
+
+TSS2_RC
+Tss2_MU_TPMS_EMPTY_Unmarshal(
+    uint8_t const   buffer[],
+    size_t          size,
+    size_t          *offset,
+    TPMS_EMPTY      *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/libmarshal.map
+++ b/lib/libmarshal.map
@@ -192,8 +192,6 @@
         Tss2_MU_TPML_INTEL_PTT_PROPERTY_Unmarshal;
         Tss2_MU_TPMU_HA_Marshal;
         Tss2_MU_TPMU_HA_Unmarshal;
-        Tss2_MU_TPMU_CAPABILITIES_Marshal;
-        Tss2_MU_TPMU_CAPABILITIES_Unmarshal;
         Tss2_MU_TPMU_ATTEST_Marshal;
         Tss2_MU_TPMU_ATTEST_Unmarshal;
         Tss2_MU_TPMU_SYM_KEY_BITS_Marshal;
@@ -212,8 +210,6 @@
         Tss2_MU_TPMU_SIGNATURE_Unmarshal;
         Tss2_MU_TPMU_SENSITIVE_COMPOSITE_Marshal;
         Tss2_MU_TPMU_SENSITIVE_COMPOSITE_Unmarshal;
-        Tss2_MU_TPMU_ENCRYPTED_SECRET_Marshal;
-        Tss2_MU_TPMU_ENCRYPTED_SECRET_Unmarshal;
         Tss2_MU_TPMU_CAPABILITIES_Marshal;
         Tss2_MU_TPMU_CAPABILITIES_Unmarshal;
         Tss2_MU_TPMU_PUBLIC_PARMS_Marshal;
@@ -256,6 +252,16 @@
         Tss2_MU_TPMT_TK_AUTH_Unmarshal;
         Tss2_MU_TPMT_TK_HASHCHECK_Marshal;
         Tss2_MU_TPMT_TK_HASHCHECK_Unmarshal;
+        Tss2_MU_TPMS_EMPTY_Marshal;
+        Tss2_MU_TPMS_EMPTY_Unmarshal;
+        Tss2_MU_TPM2_HANDLE_Marshal;
+        Tss2_MU_TPM2_HANDLE_Unmarshal;
+        Tss2_MU_TPM2_SE_Marshal;
+        Tss2_MU_TPM2_SE_Unmarshal;
+        Tss2_MU_TPMI_ALG_HASH_Marshal;
+        Tss2_MU_TPMI_ALG_HASH_Unmarshal;
+        Tss2_MU_TPMI_BYTE_Marshal;
+        Tss2_MU_TPMI_BYTE_Unmarshal;
     local:
         *;
 };

--- a/marshal/base-types.c
+++ b/marshal/base-types.c
@@ -173,6 +173,8 @@ Tss2_MU_##type##_Unmarshal ( \
  * These macros expand to (un)marshal functions for each of the base types
  * the specification part 2, table 3: Definition of Base Types.
  */
+BASE_MARSHAL  (BYTE);
+BASE_UNMARSHAL(BYTE);
 BASE_MARSHAL  (INT8);
 BASE_UNMARSHAL(INT8);
 BASE_MARSHAL  (INT16);
@@ -193,3 +195,9 @@ BASE_MARSHAL  (TPM2_CC);
 BASE_UNMARSHAL(TPM2_CC);
 BASE_MARSHAL  (TPM2_ST);
 BASE_UNMARSHAL(TPM2_ST);
+BASE_MARSHAL  (TPM2_SE);
+BASE_UNMARSHAL(TPM2_SE);
+BASE_MARSHAL  (TPM2_HANDLE);
+BASE_UNMARSHAL(TPM2_HANDLE);
+BASE_MARSHAL  (TPMI_ALG_HASH);
+BASE_UNMARSHAL(TPMI_ALG_HASH);

--- a/marshal/tpms-types.c
+++ b/marshal/tpms-types.c
@@ -243,6 +243,38 @@ static TSS2_RC unmarshal_tagged_pcr_selection(uint8_t const buffer[], size_t buf
     return TSS2_RC_SUCCESS;
 }
 
+#define TPMS_MARSHAL_0(type) \
+TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint8_t buffer[], \
+                                 size_t buffer_size, size_t *offset) \
+{ \
+    if (!src) { \
+        LOG (WARNING, "dest param is NULL"); \
+        return TSS2_TYPES_RC_BAD_REFERENCE; \
+    } \
+\
+    LOG (DEBUG, \
+         "Marshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         " at index 0x%zx", (uintptr_t)&src,  (uintptr_t)buffer, *offset); \
+\
+    return TSS2_RC_SUCCESS; \
+}
+
+#define TPMS_UNMARSHAL_0(type) \
+TSS2_RC Tss2_MU_##type##_Unmarshal(uint8_t const buffer[], size_t buffer_size, \
+                                   size_t *offset, type *dest) \
+{ \
+    if (!dest) { \
+        LOG (WARNING, "src param is NULL"); \
+        return TSS2_TYPES_RC_BAD_REFERENCE; \
+    } \
+\
+    LOG (DEBUG, \
+         "Unmarshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
+         " at index 0x%zx", (uintptr_t)dest,  (uintptr_t)buffer, *offset); \
+\
+    return TSS2_RC_SUCCESS; \
+}
+
 #define TPMS_MARSHAL_1(type, m, op, fn) \
 TSS2_RC Tss2_MU_##type##_Marshal(type const *src, uint8_t buffer[], \
                                  size_t buffer_size, size_t *offset) \
@@ -1334,3 +1366,7 @@ TPMS_MARSHAL_1(TPMS_SYMCIPHER_PARMS,
 
 TPMS_UNMARSHAL_1(TPMS_SYMCIPHER_PARMS,
                  sym, Tss2_MU_TPMT_SYM_DEF_OBJECT_Unmarshal)
+
+TPMS_MARSHAL_0(TPMS_EMPTY);
+
+TPMS_UNMARSHAL_0(TPMS_EMPTY);


### PR DESCRIPTION
Added marshaling and unmarshaling for TPM2_HANDLE,
TPMI_ALG_HASH, TPM2_SE, TPM2B_NONCE, TPMS_EMPTY, BYTE

Signed-off-by: Andreas Fuchs <andreas.fuchs@sit.fraunhofer.de>
Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>