### PR TITLE
[RFC] Make: Add silent rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -304,20 +304,20 @@ test_integration_system_api_int_SOURCES = test/integration/main.c \
 TESTS_LDADD = $(noinst_LTLIBRARIES) $(lib_LTLIBRARIES)
 
 AUTHORS :
-	git log --format='%aN <%aE>' | grep -v 'users.noreply.github.com' | sort | \
+	$(AM_V_GEN)git log --format='%aN <%aE>' | grep -v 'users.noreply.github.com' | sort | \
 	    uniq -c | sort -nr | sed 's/^\s*//' | cut -d" " -f2- > $@
 
 %.pc : %.pc.in
-	$(call make_parent_dir,$@)
+	$(AM_V_GEN)$(call make_parent_dir,$@) && \
 	sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g; \
 	        s,[@]libdir[@],$(libdir),g; \
 	        s,[@]includedir[@],$(includedir),g;" $^ > $@
 
 man/man3/%.3 : man/%.3.in $(srcdir)/man/man-postlude.troff
-	$(call make_man,$@,$<,$(srcdir)/man/man-postlude.troff)
+	$(AM_V_GEN)$(call make_man,$@,$<,$(srcdir)/man/man-postlude.troff)
 
 man/man7/%.7 : man/%.7.in $(srcdir)/man/man-postlude.troff
-	$(call make_man,$@,$<,$(srcdir)/man/man-postlude.troff)
+	$(AM_V_GEN)$(call make_man,$@,$<,$(srcdir)/man/man-postlude.troff)
 
 # simple variables
 libsapi = sysapi/libsapi.la
@@ -333,7 +333,7 @@ endef
 # $2: .in file
 # $3: man postlude file
 define make_man
-    $(call make_parent_dir,$1)
-    cat $2 $3 > $1
+    $(call make_parent_dir,$1) && \
+    cat $2 $3 > $1 && \
     sed -i -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g;" $1
 endef

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,8 @@ AC_PROG_CC
 LT_INIT()
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])]) #Backward compatible setting of "silent-rules"
+
 AC_CONFIG_FILES([Makefile])
 
 # propagate configure arguments to distcheck


### PR DESCRIPTION
IMHO, Make's output is just too cluttered... So I never see any warnings...

RFQ: Would other also like to add silent rules as proposed in this patch ?

P.S. `make V=1` still gives you the old output...