### PR TITLE
sysapi: Fixes about GetCommandCode

### DIFF
--- a/include/sapi/tss2_sys.h
+++ b/include/sapi/tss2_sys.h
@@ -148,7 +148,7 @@ TSS2_RC Tss2_Sys_Execute(
 //
 TSS2_RC Tss2_Sys_GetCommandCode(
     TSS2_SYS_CONTEXT *sysContext,
-    UINT8 (*commandCode)[4]
+    UINT8 *commandCode
     );
 
 TSS2_RC Tss2_Sys_GetRspAuths(

--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -64,7 +64,7 @@ typedef struct {
     // These are set by system API and used by helper functions to calculate cpHash,
     // rpHash, and for auditing.
     //
-    TPM2_CC commandCode;
+    TPM2_CC commandCode;    // This is in host endianess
     UINT32 cpBufferUsedSize;
     UINT8 *cpBuffer;
     UINT32 *rspParamsSize;  // Points to response paramsSize.

--- a/sysapi/sysapi/GetCommandCode.c
+++ b/sysapi/sysapi/GetCommandCode.c
@@ -31,7 +31,7 @@
 
 TSS2_RC Tss2_Sys_GetCommandCode(
     TSS2_SYS_CONTEXT *sysContext,
-    UINT8 (*commandCode)[4])
+    UINT8 *commandCode)
 {
     _TSS2_SYS_CONTEXT_BLOB *ctx = syscontext_cast(sysContext);
 
@@ -41,7 +41,8 @@ TSS2_RC Tss2_Sys_GetCommandCode(
     if (ctx->previousStage == CMD_STAGE_INITIALIZE)
         return TSS2_SYS_RC_BAD_SEQUENCE;
 
-    *(TPM2_CC *)commandCode = HOST_TO_BE_32(ctx->commandCode);
+    TPM2_CC tmp = HOST_TO_BE_32(ctx->commandCode);
+    memcpy(commandCode, (void *)&tmp, sizeof(tmp));
 
     return TSS2_RC_SUCCESS;
 }

--- a/test/integration/system-api.int.c
+++ b/test/integration/system-api.int.c
@@ -200,7 +200,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         print_fail ("SAPI invalid test FAILED! Response Code : 0x%x", rc);
 
     /* Test GetCommandCode for bad reference */
-    rc = Tss2_Sys_GetCommandCode(0, (UINT8 (*)[4])&commandCode);
+    rc = Tss2_Sys_GetCommandCode(0, (UINT8 *)&commandCode);
     if (rc != TSS2_SYS_RC_BAD_REFERENCE)
         print_fail ("SAPI invalid test FAILED! Response Code : 0x%x", rc);
 

--- a/test/tpmclient/SessionHmac.c
+++ b/test/tpmclient/SessionHmac.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "sysapi_util.h"
+#include "tss2_endian.h"
 
 //
 // This function calculates the session HMAC and updates session state.
@@ -88,9 +89,12 @@ UINT32 TpmComputeSessionHmac(
         authValue.size = 0;
     }
 
-    rval = Tss2_Sys_GetCommandCode( sysContext, (UINT8 (*)[4])&cmdCode );
+    rval = Tss2_Sys_GetCommandCode( sysContext, (UINT8 *)&cmdCode );
     if( rval != TPM2_RC_SUCCESS )
         return rval;
+
+    // cmdCode comes back as BigEndian; not suited for comparisons below.
+    cmdCode = BE_TO_HOST_32(cmdCode);
 
     if( ( entityHandle >> TPM2_HR_SHIFT ) == TPM2_HT_NV_INDEX )
     {

--- a/test/tpmclient/TpmCalcPHash.c
+++ b/test/tpmclient/TpmCalcPHash.c
@@ -118,7 +118,7 @@ TSS2_RC TpmCalcPHash( TSS2_SYS_CONTEXT *sysContext, TPM2_HANDLE handle1, TPM2_HA
     }
 
     // Create pHash input byte stream:  now add command code.
-    rval = Tss2_Sys_GetCommandCode( sysContext, (UINT8 (*)[4])&cmdCode );
+    rval = Tss2_Sys_GetCommandCode( sysContext, (UINT8 *)&cmdCode );
     if( rval != TPM2_RC_SUCCESS )
         return rval;
 


### PR DESCRIPTION
This patch updates the function signature to reflect the
latest specification version.
Further, it make the GetCommandCode function safe to use
with non-aligned arrays.
Also it fixes the tests to account for correct endianess.

Signed-off-by: Andreas Fuchs <andreas.fuchs@sit.fraunhofer.de>
Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>