### PR TITLE
bootstrap: use portable printf instead of echo

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -8,7 +8,7 @@ src_listvar () {
     suffix=$2
     var=$3
 
-    find "${basedir}" -name "${suffix}" | LC_ALL=C sort | tr '\n' ' ' | (echo -n "${var} = " && cat)
+    find "${basedir}" -name "${suffix}" | LC_ALL=C sort | tr '\n' ' ' | (printf "${var} = " && cat)
     echo ""
 }
 


### PR DESCRIPTION
The `-n` flag is not supported by the `echo` built-in of some versions
of `sh`. Use the portable `printf` instead.

Signed-off-by: David R. Bild <david.bild@xaptum.com>