### PR TITLE
sysapi: Remove double return

### DIFF
--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -154,14 +154,11 @@ TSS2_RC CommonComplete(_TSS2_SYS_CONTEXT_BLOB *ctx)
         return rval;
 
     /* Skiping over response params size field */
-    if (tag == TPM2_ST_SESSIONS) {
+    if (tag == TPM2_ST_SESSIONS)
         rval = Tss2_MU_UINT32_Unmarshal(ctx->cmdBuffer,
                                         ctx->maxCmdSize,
                                         &ctx->nextData,
                                         NULL);
-        if (rval)
-            return rval;
-    }
 
     return rval;
 }


### PR DESCRIPTION
Remove double return in CommonComplete()

Signed-off-by: Andreas Fuchs <andreas.fuchs@sit.fraunhofer.de>