### PR TITLE
configure.ac: Use fixed version for stable branch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,4 @@
-AC_INIT([tpm2-tss],
-        [m4_esyscmd_s([git describe --tags --always --dirty])])
+AC_INIT([tpm2-tss], [1.3.0])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_PROG_CXX


### PR DESCRIPTION
Having the version generated from a git tag could be useful for dev branches
and when people build from a git repository. But is not correct for released
tarballs, since attempting to execute the git command will fail and won't be
a version defined, i.e:

$ ./bootstrap
Generating file lists: src_vars.mk
fatal: Not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).

$ grep -i version lib/sapi.pc
Version:

So after a branch is released, just use a fixed version number:

$ grep -i version lib/sapi.pc
Version: 1.3.0

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>