### PR TITLE
Makefile.am: Add LICENSE in tarball generated by the make dist target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -94,6 +94,7 @@ man3_MANS = man/man3/InitDeviceTcti.3 man/man3/InitSocketTcti.3
 man7_MANS = man/man7/tcti-device.7 man/man7/tcti-socket.7
 
 EXTRA_DIST = \
+    LICENSE \
     lib/debug_config.site \
     lib/tcti-device.pc.in \
     lib/tcti-socket.pc.in \


### PR DESCRIPTION
The LICENSE file that's present in the source code is not distributed in the
tarball generated by the make dist target. Including full license text makes
it easier for people to comply with the desired license terms.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>