### PR TITLE
build: detect ld version-script flag support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -196,7 +196,9 @@ test_unit_TPMU_marshal_LDADD   = $(CMOCKA_LIBS) $(libmarshal)
 test_unit_TPMU_marshal_SOURCES = test/unit/TPMU-marshal.c
 endif # UNIT
 
+if HAVE_LD_VERSION_SCRIPT
 marshal_libmarshal_la_LDFLAGS = -Wl,--version-script=$(srcdir)/lib/libmarshal.map
+endif # HAVE_LD_VERSION_SCRIPT
 marshal_libmarshal_la_SOURCES = $(MARSHAL_SRC) log/log.c log/log.h
 
 sysapi_libsapi_la_LIBADD  = $(libmarshal)
@@ -204,13 +206,17 @@ sysapi_libsapi_la_SOURCES = $(SYSAPI_C) $(SYSAPI_H) $(SYSAPIUTIL_C) \
     $(SYSAPIUTIL_H)
 
 tcti_libtcti_device_la_CFLAGS   = $(AM_CFLAGS)
+if HAVE_LD_VERSION_SCRIPT
 tcti_libtcti_device_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/tcti/tcti_device.map
+endif # HAVE_LD_VERSION_SCRIPT
 tcti_libtcti_device_la_LIBADD   = $(libmarshal)
 tcti_libtcti_device_la_SOURCES  = tcti/tcti_device.c tcti/tcti.c \
     tcti/tcti.h common/debug.c common/debug.h tcti/logging.h
 
 tcti_libtcti_socket_la_CFLAGS   = $(AM_CFLAGS)
+if HAVE_LD_VERSION_SCRIPT
 tcti_libtcti_socket_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/tcti/tcti_socket.map
+endif # HAVE_LD_VERSION_SCRIPT
 tcti_libtcti_socket_la_SOURCES  = tcti/platformcommand.c tcti/tcti_socket.c \
     tcti/tcti.c tcti/tcti.h tcti/sockets.c tcti/sockets.h \
     common/debug.c common/debug.h tcti/logging.h

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,8 @@ AC_ARG_WITH([simulatorbin],
             [with_simulatorbin_set=no])
 AM_CONDITIONAL([SIMULATOR_BIN],[test "x$with_simulatorbin_set" = "xyes"])
 
+gl_LD_VERSION_SCRIPT
+
 AX_ADD_COMPILER_FLAG([-Wall])
 AX_ADD_COMPILER_FLAG([-Werror])
 AX_ADD_COMPILER_FLAG([-std=gnu99])

--- a/m4/ld-version-script.m4
+++ b/m4/ld-version-script.m4
@@ -1,0 +1,53 @@
+# ld-version-script.m4 serial 3
+dnl Copyright (C) 2008-2014 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# FIXME: The test below returns a false positive for mingw
+# cross-compiles, 'local:' statements does not reduce number of
+# exported symbols in a DLL.  Use --disable-ld-version-script to work
+# around the problem.
+
+# gl_LD_VERSION_SCRIPT
+# --------------------
+# Check if LD supports linker scripts, and define automake conditional
+# HAVE_LD_VERSION_SCRIPT if so.
+AC_DEFUN([gl_LD_VERSION_SCRIPT],
+[
+  AC_ARG_ENABLE([ld-version-script],
+    AS_HELP_STRING([--enable-ld-version-script],
+      [enable linker version script (default is enabled when possible)]),
+      [have_ld_version_script=$enableval], [])
+  if test -z "$have_ld_version_script"; then
+    AC_MSG_CHECKING([if LD -Wl,--version-script works])
+    save_LDFLAGS="$LDFLAGS"
+    LDFLAGS="$LDFLAGS -Wl,--version-script=conftest.map"
+    cat > conftest.map <<EOF
+foo
+EOF
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+                   [accepts_syntax_errors=yes], [accepts_syntax_errors=no])
+    if test "$accepts_syntax_errors" = no; then
+      cat > conftest.map <<EOF
+VERS_1 {
+        global: sym;
+};
+
+VERS_2 {
+        global: sym;
+} VERS_1;
+EOF
+      AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+                     [have_ld_version_script=yes], [have_ld_version_script=no])
+    else
+      have_ld_version_script=no
+    fi
+    rm -f conftest.map
+    LDFLAGS="$save_LDFLAGS"
+    AC_MSG_RESULT($have_ld_version_script)
+  fi
+  AM_CONDITIONAL(HAVE_LD_VERSION_SCRIPT, test "$have_ld_version_script" = "yes")
+])


### PR DESCRIPTION
Some linkers do not support the --version-script flag.  Only include
it if the linker supports it.

Signed-off-by: David R. Bild <david.bild@xaptum.com>