### PR TITLE
endian: fix manually-defined endian conversions

### DIFF
--- a/marshal/tss2_endian.h
+++ b/marshal/tss2_endian.h
@@ -51,8 +51,9 @@
 #define BE_TO_HOST_64(value) (value)
 
 #else
+#include <stdint.h>
 
-static inline uint16_t endian_conv_16(UINT16 value)
+static inline uint16_t endian_conv_16(uint16_t value)
 {
     return ((value & (0xff))      << 8) | \
            ((value & (0xff << 8)) >> 8);


### PR DESCRIPTION
The stdint.h include was missing, and one of the methods referred to a
non-imported typedef.

Signed-off-by: David R. Bild <david.bild@xaptum.com>