### PR TITLE
Support building on OS X

### DIFF
--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -54,7 +54,7 @@ extern "C" {
 #include "tss2_common.h"
 #include <stddef.h>
 
-#if defined(__linux__) || defined(__unix__)
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
 #include <poll.h>
 typedef struct pollfd TSS2_TCTI_POLL_HANDLE;
 #else

--- a/tcti/sockets.h
+++ b/tcti/sockets.h
@@ -18,6 +18,15 @@ int WSAGetLastError();
 #define WINAPI
 #define LPVOID void *
 
+#if !defined(MSG_NOSIGNAL)
+# if defined(SO_NOSIGPIPE)
+#   define MSG_NOSIGNAL 0
+#   define TSS2_USE_SO_NOSIGPIPE
+# else
+#   error "Neither MSG_NOSIGNAL nor SO_NOSIGPIPE is defined."
+# endif
+#endif
+
 int
 InitSockets( const char *hostName,
              UINT16 port,

--- a/tcti/tcti.h
+++ b/tcti/tcti.h
@@ -40,7 +40,7 @@
 #ifndef TSS2_TCTI_UTIL_H
 #define TSS2_TCTI_UTIL_H
 
-#if defined(__linux__) || defined(__unix__)
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
 #include <sys/socket.h>
 #define SOCKET int
 #endif


### PR DESCRIPTION
This patch series adds support for building on Mac OS X by cleaning up some imports and using the BSD method for blocking SIGPIPE.

Unit tests (`make check`) do not build because the OS X linker does not support the `--wrap` flag.  Some unit tests depend on symbol wrapping, and there is not an easy way to mimic this behavior on OS X. 

The primary goal of this change is to enable OS X users to experiment with TPM 2 via the TSS and simulator, not to enable development of the TSS itself on OS X. So the lack of unit test support should be acceptable.  Regardless, this patch series does increase portability, at least incrementally.

N.B. Building on OS X requires PRs #647 and #648 as well.