### PR TITLE
Fix scan-build warnings

### DIFF
--- a/sysapi/sysapi/Tss2_Sys_EvictControl.c
+++ b/sysapi/sysapi/Tss2_Sys_EvictControl.c
@@ -41,6 +41,8 @@ TSS2_RC Tss2_Sys_EvictControl_Prepare(
         return TSS2_SYS_RC_BAD_REFERENCE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_EvictControl);
+    if (rval)
+        return rval;
 
     rval = Tss2_MU_UINT32_Marshal(auth, ctx->cmdBuffer,
                                   ctx->maxCmdSize,

--- a/sysapi/sysapi/Tss2_Sys_LoadExternal.c
+++ b/sysapi/sysapi/Tss2_Sys_LoadExternal.c
@@ -41,6 +41,8 @@ TSS2_RC Tss2_Sys_LoadExternal_Prepare(
         return TSS2_SYS_RC_BAD_REFERENCE;
 
     rval = CommonPreparePrologue(ctx, TPM2_CC_LoadExternal);
+    if (rval)
+        return rval;
 
     /* If no private key is specified, set the private key size field to 0 */
     if (!inPrivate) {

--- a/tcti/sockets.c
+++ b/tcti/sockets.c
@@ -108,7 +108,7 @@ InitSockets( const char *hostName,
     iResult = connect(*otherSock, (SOCKADDR *) &otherService, sizeof (otherService));
     if (iResult == SOCKET_ERROR) {
         SAFE_CALL( debugfunc, data, NO_PREFIX, "connect function failed with error: %d\n", WSAGetLastError() );
-        iResult = closesocket(*otherSock);
+        closesocket(*otherSock);
         WSACleanup();
         return 1;
     }

--- a/tcti/tcti_socket.c
+++ b/tcti/tcti_socket.c
@@ -182,12 +182,19 @@ TSS2_RC SocketSendTpmCommand(
                                      command_size,
                                      &offset,
                                      &cnt);
+    if (rval != TSS2_RC_SUCCESS) {
+        return rval;
+    }
 
     /* Send TPM2_SEND_COMMAND */
     rval = Tss2_MU_UINT32_Marshal (MS_SIM_TPM_SEND_COMMAND,
                            (uint8_t*)&tpmSendCommand,
                            sizeof (tpmSendCommand),
                            NULL);  /* Value for "send command" to MS simulator. */
+    if (rval != TSS2_RC_SUCCESS) {
+        return rval;
+    }
+
     rval = tctiSendBytes (tctiContext,
                           tcti_intel->tpmSock,
                           (unsigned char *)&tpmSendCommand,

--- a/test/tpmclient/SessionHmac.c
+++ b/test/tpmclient/SessionHmac.c
@@ -101,11 +101,15 @@ UINT32 TpmComputeSessionHmac(
     }
 
     rval = ConcatSizedByteBuffer((TPM2B_MAX_BUFFER *)&hmacKey, (TPM2B *)&pSession->sessionKey);
+    if( rval != TPM2_RC_SUCCESS )
+        return rval;
 
     if( ( pSession->bind == TPM2_RH_NULL ) || ( pSession->bind != entityHandle )
             || nvNameChanged )
     {
         rval = ConcatSizedByteBuffer((TPM2B_MAX_BUFFER *)&hmacKey, (TPM2B *)&authValue);
+        if( rval != TPM2_RC_SUCCESS )
+            return rval;
     }
 
 #ifdef  DEBUG

--- a/test/tpmclient/TpmCalcPHash.c
+++ b/test/tpmclient/TpmCalcPHash.c
@@ -114,7 +114,6 @@ TSS2_RC TpmCalcPHash( TSS2_SYS_CONTEXT *sysContext, TPM2_HANDLE handle1, TPM2_HA
         hashInputPtr = &( hashInput.buffer[hashInput.size] );
         *(UINT32 *)hashInputPtr = BE_TO_HOST_32(responseCode);
         hashInput.size += 4;
-        hashInputPtr += 4;
     }
 
     // Create pHash input byte stream:  now add command code.

--- a/test/tpmclient/tpmclient.int.c
+++ b/test/tpmclient/tpmclient.int.c
@@ -575,8 +575,10 @@ void TestStartAuthSession()
     for( i = 0; i < ( sizeof(sessions) / sizeof (SESSION *)); i++ )
     {
         rval = Tss2_Sys_FlushContext( sysContext, sessions[i]->sessionHandle );
+        CheckPassed( rval );
 
         rval = EndAuthSession( sessions[i] );
+        CheckPassed( rval );
     }
 
     // Now do some gap tests.
@@ -2659,6 +2661,7 @@ void TestUnseal()
 
     INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_Unseal( sysContext, loadedObjectHandle, &sessionsData, &outData, &sessionsDataOut );
+    CheckPassed( rval );
 
     rval = Tss2_Sys_FlushContext( sysContext, loadedObjectHandle );
 
@@ -3713,6 +3716,7 @@ void TestEncryptDecryptSession()
             &nvAuth, &authPolicy, TPM20_INDEX_TEST1,
             TPM2_ALG_SHA1, nvAttributes,
             sizeof( writeDataString ) );
+    CheckPassed( rval );
 
     //
     // 1st pass with CFB mode.

--- a/test/unit/TPM2B-marshal.c
+++ b/test/unit/TPM2B-marshal.c
@@ -112,8 +112,7 @@ tpm2b_marshal_buffer_null_with_offset(void **state)
     TPM2B_DIGEST dgst = {4, {0}};
     TPM2B_ECC_POINT point = {sizeof(TPMS_ECC_POINT), {0}};
     size_t offset = 10;
-    uint8_t buffer[sizeof(dgst) + sizeof(point) + 10] = {0};
-    size_t  buffer_size = sizeof(buffer);
+    size_t  buffer_size = sizeof(dgst) + sizeof(point) + 10;
     uint32_t value = 0xdeadbeef;
     uint64_t value2 = 0xdeadbeefdeadbeefULL;
 

--- a/test/unit/TPMA-marshal.c
+++ b/test/unit/TPMA-marshal.c
@@ -240,9 +240,8 @@ tpma_unmarshal_buffer_null_offset_null(void **state)
 static void
 tpma_unmarshal_dest_null_offset_valid(void **state)
 {
-    TPMA_ALGORITHM alg = {0};
     TPMA_SESSION session = {0};
-    uint8_t buffer[sizeof(alg) + sizeof(session)] = { 0 };
+    uint8_t buffer[sizeof(TPMA_ALGORITHM) + sizeof(session)] = { 0 };
     size_t buffer_size = sizeof(buffer);
     size_t offset = 0;
     uint32_t alg_expected = HOST_TO_BE_32(TPMA_ALGORITHM_ASYMMETRIC | TPMA_ALGORITHM_SIGNING);
@@ -257,16 +256,9 @@ tpma_unmarshal_dest_null_offset_valid(void **state)
     *ptr = alg_expected;
     *ptr2 = session_expected;
 
-    alg |= TPMA_ALGORITHM_ASYMMETRIC;
-    alg |= TPMA_ALGORITHM_SIGNING;
-
     rc = Tss2_MU_TPMA_ALGORITHM_Unmarshal(buffer, buffer_size, &offset, NULL);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (offset, sizeof(alg));
-
-    session |= TPMA_SESSION_AUDIT;
-    session |= TPMA_SESSION_DECRYPT;
-    session |= TPMA_SESSION_AUDITRESET;
+    assert_int_equal (offset, sizeof(TPMA_ALGORITHM));
 
     rc = Tss2_MU_TPMA_SESSION_Unmarshal(buffer, buffer_size, &offset, NULL);
     assert_int_equal (rc, TSS2_RC_SUCCESS);

--- a/test/unit/TPML-marshal.c
+++ b/test/unit/TPML-marshal.c
@@ -120,8 +120,7 @@ tpml_marshal_buffer_null_with_offset(void **state)
 {
     TPML_HANDLE hndl = {0};
     TPML_PCR_SELECTION sel = {0};
-    uint8_t buffer[sizeof(hndl) + sizeof(sel) + 99] = { 0 };
-    size_t  buffer_size = sizeof(buffer);
+    size_t  buffer_size = sizeof(hndl) + sizeof(sel) + 99;
     size_t offset = 99;
     TSS2_RC rc;
 
@@ -319,9 +318,7 @@ tpml_unmarshal_dest_null_buff_null(void **state)
 static void
 tpml_unmarshal_buffer_null_offset_null(void **state)
 {
-    TPML_HANDLE hndl = {0};
-    TPML_PCR_SELECTION sel = {0};
-    uint8_t buffer[sizeof(hndl) + sizeof(sel)] = { 0 };
+    uint8_t buffer[sizeof(TPML_HANDLE) + sizeof(TPML_PCR_SELECTION)] = { 0 };
     size_t  buffer_size = sizeof(buffer);
     TSS2_RC rc;
 
@@ -339,9 +336,7 @@ tpml_unmarshal_buffer_null_offset_null(void **state)
 static void
 tpml_unmarshal_dest_null_offset_valid(void **state)
 {
-    TPML_HANDLE hndl = {0};
-    TPML_PCR_SELECTION sel = {0};
-    uint8_t buffer[sizeof(hndl) + sizeof(sel) + 10] = { 0 };
+    uint8_t buffer[sizeof(TPML_HANDLE) + sizeof(TPML_PCR_SELECTION) + 10] = { 0 };
     size_t  buffer_size = sizeof(buffer);
     TPML_HANDLE *ptr;
     size_t offset = 0;
@@ -378,9 +373,7 @@ tpml_unmarshal_dest_null_offset_valid(void **state)
 static void
 tpml_unmarshal_buffer_size_lt_data_nad_lt_offset(void **state)
 {
-    TPML_HANDLE hndl = {0};
-    TPML_PCR_SELECTION sel = {0};
-    uint8_t buffer[sizeof(hndl) + sizeof(sel)] = { 0 };
+    uint8_t buffer[sizeof(TPML_HANDLE) + sizeof(TPML_PCR_SELECTION)] = { 0 };
     TPML_HANDLE *ptr;
     size_t offset = 2;
     TSS2_RC rc;

--- a/test/unit/TPMS-marshal.c
+++ b/test/unit/TPMS-marshal.c
@@ -251,9 +251,7 @@ tpms_unmarshal_dest_null_buff_null(void **state)
 static void
 tpms_unmarshal_buffer_null_offset_null(void **state)
 {
-    TPMS_ALG_PROPERTY alg = {0};
-    TPMS_CAPABILITY_DATA cap = {0};
-    uint8_t buffer[sizeof(alg) + sizeof(cap)] = { 0 };
+    uint8_t buffer[sizeof(TPMS_ALG_PROPERTY) + sizeof(TPMS_CAPABILITY_DATA)] = { 0 };
     size_t  buffer_size = sizeof(buffer);
     TSS2_RC rc;
 
@@ -271,9 +269,7 @@ tpms_unmarshal_buffer_null_offset_null(void **state)
 static void
 tpms_unmarshal_dest_null_offset_valid(void **state)
 {
-    TPMS_ALG_PROPERTY alg = {0};
-    TPMS_CAPABILITY_DATA cap = {0};
-    uint8_t buffer[sizeof(alg) + sizeof(cap)] = { 0 };
+    uint8_t buffer[sizeof(TPMS_ALG_PROPERTY) + sizeof(TPMS_CAPABILITY_DATA)] = { 0 };
     size_t  buffer_size = sizeof(buffer);
     uint16_t *alg_ptr;
     uint32_t *alg_properties_ptr;
@@ -290,17 +286,17 @@ tpms_unmarshal_dest_null_offset_valid(void **state)
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (offset, sizeof(*alg_ptr) + sizeof(*alg_properties_ptr));
 
-    ptr2 = (TPMS_CAPABILITY_DATA *)(buffer + sizeof(alg));
+    ptr2 = (TPMS_CAPABILITY_DATA *)(buffer + sizeof(TPMS_ALG_PROPERTY));
     ptr2->capability = HOST_TO_BE_32(TPM2_CAP_ECC_CURVES);
     ptr2->data.eccCurves.count = HOST_TO_BE_32(3);
     ptr2->data.eccCurves.eccCurves[0] = HOST_TO_BE_16(TPM2_ECC_NIST_P256);
     ptr2->data.eccCurves.eccCurves[1] = HOST_TO_BE_16(TPM2_ECC_NIST_P384);
     ptr2->data.eccCurves.eccCurves[2] = HOST_TO_BE_16(TPM2_ECC_NIST_P521);
 
-    offset = sizeof(alg);
+    offset = sizeof(TPMS_ALG_PROPERTY);
     rc = Tss2_MU_TPMS_CAPABILITY_DATA_Unmarshal(buffer, buffer_size, &offset, NULL);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (offset, sizeof(alg) + 4 + 4 + (3 * 2));
+    assert_int_equal (offset, sizeof(TPMS_ALG_PROPERTY) + 4 + 4 + (3 * 2));
 }
 
 /*

--- a/test/unit/TPMT-marshal.c
+++ b/test/unit/TPMT-marshal.c
@@ -122,8 +122,7 @@ tpmt_marshal_buffer_null_with_offset(void **state)
 {
     TPMT_TK_CREATION tkt = {0};
     TPMT_PUBLIC_PARMS pub = {0};
-    uint8_t buffer[sizeof(tkt) + sizeof(pub) + 10] = { 0 };
-    size_t  buffer_size = sizeof(buffer);
+    size_t  buffer_size = sizeof(tkt) + sizeof(pub) + 10;
     size_t offset = 10;
     TSS2_RC rc;
 
@@ -277,9 +276,7 @@ tpmt_unmarshal_dest_null_buff_null(void **state)
 static void
 tpmt_unmarshal_buffer_null_offset_null(void **state)
 {
-    TPMT_TK_CREATION tkt = {0};
-    TPMT_PUBLIC_PARMS pub = {0};
-    uint8_t buffer[sizeof(tkt) + sizeof(pub)] = { 0 };
+    uint8_t buffer[sizeof(TPMT_TK_CREATION) + sizeof(TPMT_PUBLIC_PARMS)] = { 0 };
     size_t  buffer_size = sizeof(buffer);
     TSS2_RC rc;
 
@@ -297,9 +294,8 @@ tpmt_unmarshal_buffer_null_offset_null(void **state)
 static void
 tpmt_unmarshal_dest_null_offset_valid(void **state)
 {
-    TPMT_TK_CREATION tkt = {0};
-    TPMT_PUBLIC_PARMS pub = {0};
-    uint8_t buffer[sizeof(tkt) + sizeof(pub)] = { 0 };
+    TPMT_TK_CREATION tkt;
+    uint8_t buffer[sizeof(tkt) + sizeof(TPMT_PUBLIC_PARMS)] = { 0 };
     size_t  buffer_size = sizeof(buffer);
     TPMT_TK_CREATION *ptr;
     TPMI_RH_HIERARCHY *ptr2;
@@ -343,9 +339,8 @@ tpmt_unmarshal_dest_null_offset_valid(void **state)
 static void
 tpmt_unmarshal_buffer_size_lt_data_nad_lt_offset(void **state)
 {
-    TPMT_TK_CREATION tkt = {0};
-    TPMT_PUBLIC_PARMS pub = {0};
-    uint8_t buffer[sizeof(tkt) + sizeof(pub)] = { 0 };
+    TPMT_TK_CREATION tkt;
+    uint8_t buffer[sizeof(tkt) + sizeof(TPMT_PUBLIC_PARMS)] = { 0 };
     TPMT_TK_CREATION *ptr;
     TPMI_RH_HIERARCHY *ptr2;
     TPM2B_DIGEST *ptr3;

--- a/test/unit/TPMU-marshal.c
+++ b/test/unit/TPMU-marshal.c
@@ -113,8 +113,7 @@ tpmu_marshal_buffer_null_with_offset(void **state)
 {
     TPMU_HA ha = {0};
     TPMU_SIGNATURE sig = {0};
-    uint8_t buffer[sizeof(ha) + sizeof(sig) + 10] = { 0 };
-    size_t  buffer_size = sizeof(buffer);
+    size_t  buffer_size = sizeof(ha) + sizeof(sig) + 10;
     size_t offset = 10;
     TSS2_RC rc;
 
@@ -267,9 +266,7 @@ tpmu_unmarshal_dest_null_buff_null(void **state)
 static void
 tpmu_unmarshal_buffer_null_offset_null(void **state)
 {
-    TPMU_HA ha = {0};
-    TPMU_SIGNATURE sig = {0};
-    uint8_t buffer[sizeof(ha) + sizeof(sig)] = { 0 };
+    uint8_t buffer[sizeof(TPMU_HA) + sizeof(TPMU_SIGNATURE)] = { 0 };
     size_t  buffer_size = sizeof(buffer);
     TSS2_RC rc;
 
@@ -287,9 +284,7 @@ tpmu_unmarshal_buffer_null_offset_null(void **state)
 static void
 tpmu_unmarshal_dest_null_offset_valid(void **state)
 {
-    TPMU_HA ha = {0};
-    TPMU_SIGNATURE sig = {0};
-    uint8_t buffer[sizeof(ha) + sizeof(sig)] = { 0 };
+    uint8_t buffer[sizeof(TPMU_HA) + sizeof(TPMU_SIGNATURE)] = { 0 };
     size_t  buffer_size = sizeof(buffer);
     TPMS_SIGNATURE_ECDSA *ptr;
     TPM2B_ECC_PARAMETER *ptr2;

--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -117,11 +117,10 @@ tcti_device_log_called_test (void **state)
     assert_non_null (ctx);
     ret = InitDeviceTcti (ctx, 0, &conf);
     assert_true (ret == TSS2_RC_SUCCESS);
-    if (ctx)
-        free (ctx);
     /* the 'called' variable should be changed from false to true after this */
     TCTI_LOG (ctx, NO_PREFIX, "test log call");
     assert_true (called);
+    free (ctx);
 }
 /* end tcti_dev_init_log */
 /* wrap functions for read & write required to test receive / transmit */


### PR DESCRIPTION
Fix warnings and errors from clang scan-build

Includes 1 actual error of use-after-free and a bunch of unused variables and return code warnings.