### PR TITLE
travis: ensure COVERALLS_REPO_TOKEN is set before uploading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,6 @@ script:
   - cat test/tpmclient/tpmclient.log
   - popd
   - |
-    if [ "$CC" == "gcc" ]; then
+    if [ "$CC" == "gcc" -a -n "$COVERALLS_REPO_TOKEN" ]; then
         coveralls --build-root=build --gcov-options '\-lp'
     fi


### PR DESCRIPTION
PRs from 3rd party repos don't have access to encrypted env
variables.

For example, see:
https://travis-ci.org/intel/tpm2-tss/jobs/315268038

Signed-off-by: William Roberts <william.c.roberts@intel.com>