### PR TITLE
build: Have supported compilers use 'c99' language standard instead o…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,12 +45,14 @@ gl_LD_VERSION_SCRIPT
 
 AX_ADD_COMPILER_FLAG([-Wall])
 AX_ADD_COMPILER_FLAG([-Werror])
-AX_ADD_COMPILER_FLAG([-std=gnu99])
+AX_ADD_COMPILER_FLAG([-std=c99])
 AX_ADD_COMPILER_FLAG([-Wformat])
 AX_ADD_COMPILER_FLAG([-Wformat-security])
 AX_ADD_COMPILER_FLAG([-fstack-protector-all])
 AX_ADD_COMPILER_FLAG([-fpic])
 AX_ADD_COMPILER_FLAG([-fPIC])
+
+AX_ADD_PREPROC_FLAG([-D_DEFAULT_SOURCE])
 
 AC_ARG_ENABLE([debug],
             [AS_HELP_STRING([--enable-debug],


### PR DESCRIPTION
…f 'gnu99'.

The difference between c99 and gnu99 is documented here:
https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html#C-Dialect-Options

The intent of the TCG APIs is to be c99 compliant. Using gnu99 is nearly
identical to c99 but a number of optional GNU extentions and feature
test macros are enabled by default. Using c99 means we'll have to
explicitly include them through feature macros as they're required.

Our use of endian.h requires that we now define the _DEFAULT_SOURCE
macro. This macro is documented here:
https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>