### PR TITLE
Define TPMS_EMPTY structure to have a BYTE array with a single member.

### DIFF
--- a/include/sapi/tss2_tpm2_types.h
+++ b/include/sapi/tss2_tpm2_types.h
@@ -1185,7 +1185,7 @@ typedef	TPM2_ST TPMI_ST_COMMAND_TAG;
 
 /* Table 68  Definition of TPMS_EMPTY Structure <INOUT> */
 typedef	struct {
-	BYTE empty[0];	 /* a structure with no member  */
+	BYTE empty[1];	 /* a structure with no member  */
 } TPMS_EMPTY;
 
 /* Table 69  Definition of TPMS_ALGORITHM_DESCRIPTION Structure <OUT> */


### PR DESCRIPTION
If define as an array with 0 members this causes pedantic C compilers to
complain of the invalid 0 sized array (disallowed by c99).

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>