### PR TITLE
tcti: Remove unused log data from device TCTI config structure.

### DIFF
--- a/include/tcti/tcti_device.h
+++ b/include/tcti/tcti_device.h
@@ -37,8 +37,6 @@ extern "C" {
 
 typedef struct {
     const char *device_path;
-    TCTI_LOG_CALLBACK logCallback;
-    void *logData;
 } TCTI_DEVICE_CONF;
 
 TSS2_RC InitDeviceTcti (


### PR DESCRIPTION
These fields have been unused since
43a0d76bf4e8f50b164a8be89102f1de03d46fa6.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>