### PR TITLE
common TCTI init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
     packages:
     - autoconf-archive
     - cmake
+    - liburiparser-dev
     - realpath
     - lcov
   coverity_scan:

--- a/Makefile.am
+++ b/Makefile.am
@@ -140,8 +140,8 @@ test_unit_tcti_device_LDFLAGS = -Wl,--wrap=read -Wl,-wrap=write
 test_unit_tcti_device_SOURCES = tcti/tcti.c tcti/tcti.h tcti/tcti_device.c \
     test/unit/tcti-device.c log/log.h log/log.c
 
-test_unit_tcti_socket_CFLAGS  = $(CMOCKA_CFLAGS) $(AM_CFLAGS)
-test_unit_tcti_socket_LDADD   = $(CMOCKA_LIBS) $(libmarshal)
+test_unit_tcti_socket_CFLAGS  = $(CMOCKA_CFLAGS) $(AM_CFLAGS) $(URIPARSER_CFLAGS)
+test_unit_tcti_socket_LDADD   = $(CMOCKA_LIBS) $(libmarshal) $(URIPARSER_LIBS)
 test_unit_tcti_socket_LDFLAGS = -Wl,--wrap=connect,--wrap=recv,--wrap=select,--wrap=send
 test_unit_tcti_socket_SOURCES = tcti/platformcommand.c tcti/tcti_socket.c \
     tcti/tcti.c tcti/tcti.h tcti/sockets.c tcti/sockets.h \
@@ -219,11 +219,11 @@ tcti_libtcti_device_la_LIBADD   = $(libmarshal)
 tcti_libtcti_device_la_SOURCES  = tcti/tcti_device.c tcti/tcti.c \
     tcti/tcti.h log/log.h log/log.c
 
-tcti_libtcti_socket_la_CFLAGS   = $(AM_CFLAGS)
+tcti_libtcti_socket_la_CFLAGS   = $(AM_CFLAGS) $(URIPARSER_CFLAGS)
 if HAVE_LD_VERSION_SCRIPT
 tcti_libtcti_socket_la_LDFLAGS  = -Wl,--version-script=$(srcdir)/tcti/tcti_socket.map
 endif # HAVE_LD_VERSION_SCRIPT
-tcti_libtcti_socket_la_LIBADD   = $(libmarshal)
+tcti_libtcti_socket_la_LIBADD   = $(libmarshal) $(URIPARSER_LIBS)
 tcti_libtcti_socket_la_SOURCES  = tcti/platformcommand.c tcti/tcti_socket.c \
     tcti/tcti.c tcti/tcti.h tcti/sockets.c tcti/sockets.h log/log.h log/log.c
 

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,10 @@ AS_IF([test "x$enable_unit" != xno],
                          [AC_DEFINE([HAVE_CMOCKA],
                                     [1])])])
 AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
+
+# Uriparser library required by simulator TCTI library.
+PKG_CHECK_MODULES([URIPARSER],[liburiparser])
+
 #
 # simulator binary
 #

--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2015 - 2017, Intel Corporation
 //
 // Copyright 2015, Andreas Fuchs @ Fraunhofer SIT
 //
@@ -164,6 +164,23 @@ TSS2_TCTI_POLL_HANDLE *handles, size_t *num_handles);
 } TSS2_TCTI_CONTEXT_COMMON_V1;
 
 typedef TSS2_TCTI_CONTEXT_COMMON_V1 TSS2_TCTI_CONTEXT_COMMON_CURRENT;
+
+#define TCTI_INFO_SYMBOL "Tss2_Tcti_Info"
+
+typedef TSS2_RC (*TSS2_TCTI_INIT_FUNC) (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *config
+    );
+
+typedef struct {
+    const char *name;
+    const char *description;
+    const char *config_help;
+    TSS2_TCTI_INIT_FUNC init;
+} TSS2_TCTI_INFO;
+
+typedef const TSS2_TCTI_INFO* (*TSS2_TCTI_INFO_FUNC) (void);
 
 #ifdef __cplusplus
 }

--- a/include/tcti/tcti_device.h
+++ b/include/tcti/tcti_device.h
@@ -45,6 +45,12 @@ TSS2_RC InitDeviceTcti (
     const TCTI_DEVICE_CONF *config  // IN
     );
 
+TSS2_RC Tss2_Tcti_Device_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf
+    );
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -64,6 +64,12 @@ TSS2_RC SendSessionEndSocketTcti(
     UINT8 tpmCmdServer
     );
 
+TSS2_RC Tss2_Tcti_Socket_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf
+    );
+
 // Commands to send to OTHER port.
 #define MS_SIM_POWER_ON         1
 #define MS_SIM_POWER_OFF        2

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -41,6 +41,8 @@
 #define LOGMODULE tcti
 #include "log/log.h"
 
+#define TCTI_DEVICE_DEFAULT "/dev/tpm0"
+
 TSS2_RC LocalTpmSendTpmCommand(
     TSS2_TCTI_CONTEXT *tctiContext,
     size_t command_size,
@@ -233,4 +235,31 @@ TSS2_RC InitDeviceTcti (
     }
 
     return rval;
+}
+
+TSS2_RC Tss2_Tcti_Device_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf
+    )
+{
+    const char *dev_path = conf != NULL ? conf : TCTI_DEVICE_DEFAULT;
+    TCTI_DEVICE_CONF dev_conf = {
+        .device_path = dev_path,
+    };
+
+    return InitDeviceTcti (tctiContext, size, &dev_conf);
+}
+
+const static TSS2_TCTI_INFO tss2_tcti_info = {
+    .name = "tcti-device",
+    .description = "TCTI module for communication with Linux kernel interface.",
+    .config_help = "Path to TPM character device: \"/dev/tpm0\" is default.",
+    .init = Tss2_Tcti_Device_Init,
+};
+
+const TSS2_TCTI_INFO*
+Tss2_Tcti_Info (void)
+{
+    return &tss2_tcti_info;
 }

--- a/tcti/tcti_device.map
+++ b/tcti/tcti_device.map
@@ -1,6 +1,8 @@
 {
     global:
         InitDeviceTcti;
+        Tss2_Tcti_Device_Init;
+        Tss2_Tcti_Info;
     local:
         *;
 };

--- a/tcti/tcti_socket.map
+++ b/tcti/tcti_socket.map
@@ -2,6 +2,8 @@
     global:
         InitSocketTcti;
         PlatformCommand;
+        Tss2_Tcti_Info;
+        Tss2_Tcti_Socket_Init;
     local:
         *;
 };


### PR DESCRIPTION
This resolves #690. Next step is to remove the old init functions but the test harnesses for the various projects need to be updated first. I've also got some example code in a topic branch for the tools: https://github.com/flihp/tpm2-tools/tree/tcti-init-v3 but for the time the old interface is still in use.