### PR TITLE
tcti: Add 'TSS2_' prefix to TCTI_INFO_SYMBOL macro.

### DIFF
--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -165,7 +165,7 @@ TSS2_TCTI_POLL_HANDLE *handles, size_t *num_handles);
 
 typedef TSS2_TCTI_CONTEXT_COMMON_V1 TSS2_TCTI_CONTEXT_COMMON_CURRENT;
 
-#define TCTI_INFO_SYMBOL "Tss2_Tcti_Info"
+#define TSS2_TCTI_INFO_SYMBOL "Tss2_Tcti_Info"
 
 typedef TSS2_RC (*TSS2_TCTI_INIT_FUNC) (
     TSS2_TCTI_CONTEXT *tctiContext,


### PR DESCRIPTION
The TSS2_ prefix is how the TCG specs attempt prevent conflicts with symbols
/ macros from other libraries / headers. Since this macro is in a public
header it should have this prefix.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>