### PR TITLE
log: Wrap use of compiler specific attributes in a macro.

### DIFF
--- a/log/log.h
+++ b/log/log.h
@@ -12,6 +12,12 @@
 #define LOGDEFAULT LOGLEVEL_WARNING
 #endif
 
+#if defined (__GNUC__)
+#define COMPILER_ATTR(...) __attribute__((__VA_ARGS__))
+#else
+#define COMPILER_ATTR(...)
+#endif
+
 typedef enum {
     LOGLEVEL_NONE     = 0,
     LOGLEVEL_ERROR    = 1,
@@ -22,7 +28,7 @@ typedef enum {
     LOGLEVEL_UNDEFINED    = 0xff
 } log_level;
 
-static const char *log_strings[] __attribute__((unused)) = {
+static const char *log_strings[] COMPILER_ATTR(unused) = {
     "none",
     "ERROR",
     "WARNING",
@@ -34,7 +40,7 @@ static const char *log_strings[] __attribute__((unused)) = {
 #define xstr(s) str(s)
 #define str(s) #s
 
-static log_level LOGMODULE_status __attribute__((unused)) = LOGLEVEL_UNDEFINED;
+static log_level LOGMODULE_status COMPILER_ATTR(unused) = LOGLEVEL_UNDEFINED;
 
 #if LOGLEVEL == LOGLEVEL_ERROR || \
     LOGLEVEL == LOGLEVEL_WARNING || \
@@ -136,13 +142,13 @@ doLog(log_level loglevel, const char *module, log_level logdefault,
        log_level *status,
        const char *file, const char *func, int line,
        const char *msg, ...)
-    __attribute__((unused, format (printf, 8, 9)));
+    COMPILER_ATTR(unused, format (printf, 8, 9));
 
 void
 doLogBlob(log_level loglevel, const char *module, log_level logdefault,
           log_level *status,
           const char *file, const char *func, int line,
           const uint8_t *buffer, size_t size, const char *msg, ...)
-    __attribute__((unused, format (printf, 10, 11)));
+    COMPILER_ATTR(unused, format (printf, 10, 11));
 
 #endif /* LOG_H */


### PR DESCRIPTION
Compiler macros are handy but only for people using compatible
compilers. This patch wraps our use of these compiler specific keywords
in an additional layer of macros. We detect the compiler type using a
compiler specific macro (only GCC compatible compilers currently) and
define COMPILER_ATTR accordingly.

When we add support for additional compilers we can add additional
tests.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>