### PR TITLE
doc: Document exceptions to function and variable naming convention.

### DIFF
--- a/doc/coding_standard_c.md
+++ b/doc/coding_standard_c.md
@@ -70,6 +70,12 @@ underscores.
 Objects created using the GObject system follow the GObject naming convention
 with individual words in object names as upper case characters.
 
+### Exceptions
+Exceptions to these rules are made for compliance with the TCG
+specifications. All function names, parameters, and other data types must
+be implemented faithfully to the specification and so may violate the naming
+conventions defined here.
+
 ### Examples
 ```c
 unsigned int table_index = find_index(jacket_table, “color”, COLOR_RED);


### PR DESCRIPTION
The TCG specs uses camelCase and Some_Other_Weird_Form heavily. To
maintain compatibility we must make exceptions for this stuff.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>