### PR TITLE
build: Have supported glibc versions before 2.19.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,7 @@ AX_ADD_COMPILER_FLAG([-fpic])
 AX_ADD_COMPILER_FLAG([-fPIC])
 
 AX_ADD_PREPROC_FLAG([-D_DEFAULT_SOURCE])
+AX_ADD_PREPROC_FLAG([-D_BSD_SOURCE])
 
 AC_ARG_WITH([loglevel],
             [AS_HELP_STRING([--with-loglevel={none,error,warning,info,debug,trace}],


### PR DESCRIPTION
When using glibc < 2.19, the use of endian.h requires the
old macro _BSD_SOURCE instead of the new one _DEFAULT_SOURCE.