### PR TITLE
[RFC] Add (M|Unm)arshal functions for TPMU_NAME.

### DIFF
--- a/include/sapi/tss2_mu.h
+++ b/include/sapi/tss2_mu.h
@@ -1604,6 +1604,22 @@ Tss2_MU_TPMU_PUBLIC_PARMS_Unmarshal(
     TPMU_PUBLIC_PARMS *dest);
 
 TSS2_RC
+Tss2_MU_TPMU_NAME_Marshal(
+    TPMU_NAME const *src,
+    uint32_t         selector,
+    uint8_t          buffer[],
+    size_t           buffer_size,
+    size_t          *offset);
+
+TSS2_RC
+Tss2_MU_TPMU_NAME_Unmarshal(
+    uint8_t const buffer[],
+    size_t        buffer_size,
+    size_t       *offset,
+    uint32_t      selector,
+    TPMU_NAME    *dest);
+
+TSS2_RC
 Tss2_MU_TPMU_PUBLIC_ID_Marshal(
     TPMU_PUBLIC_ID const *src,
     uint32_t       selector_value,

--- a/marshal/tpmu-types.c
+++ b/marshal/tpmu-types.c
@@ -519,3 +519,10 @@ TPMU_UNMARSHAL2(TPMU_PUBLIC_PARMS, TPM2_ALG_KEYEDHASH, keyedHashDetail, Tss2_MU_
                 TPM2_ALG_SYMCIPHER, symDetail, Tss2_MU_TPMS_SYMCIPHER_PARMS_Unmarshal,
                 TPM2_ALG_RSA, rsaDetail, Tss2_MU_TPMS_RSA_PARMS_Unmarshal,
                 TPM2_ALG_ECC, eccDetail, Tss2_MU_TPMS_ECC_PARMS_Unmarshal)
+
+TPMU_MARSHAL2(TPMU_NAME,
+    1, ADDR, digest, Tss2_MU_TPMT_HA_Marshal,
+    0, VAL, handle, Tss2_MU_TPM2_HANDLE_Marshal)
+TPMU_UNMARSHAL2(TPMU_NAME,
+    1, digest, Tss2_MU_TPMT_HA_Unmarshal,
+    0, handle, Tss2_MU_TPM2_HANDLE_Unmarshal)


### PR DESCRIPTION
!!DO NOT MERGE!!

This is an RFC with hopes to get some consensus on what to do about
marshalling functions for the TPMU_NAME type. This union type is a
special case that I wasn't aware of till now. It's a special case
because the spec doesn't define a selector for it (see table 10.5.2 in
the part 2). Instead the member that defines the name (either a hash or
a handle) is determined by circumstance: entities that are defined by a
public area (objects and indexes) the name is the hash of the public
structure. For entities not defined by a public area, the name is a
handle (described in 10.5.1 of part 2).

To be compliant with the TSS2 marshalling API spec we must provide
functions for (M|Unm)arshalling TPMU_NAME types but the circumstantial
handling (as opposed to selector-based like all other TPMU_* types)
makes this difficult (impossible?). As it's written now, the marshalling
spec declares the (Unm|M)arshal functions for the TPMU_NAME type with a
selector. This makes little sense since there are no selectors.

So far our implementation of libmu doesn't use this function internally
(why we have no implementation of it). The only place this may be needed
is in the marshalling of the TPM2B_NAME type. In this case we currently
marshal the TPMU_NAME as a byte array which AFAIK will make our
(M|Unm)arshaling of a TPMU_NAME that's a handle wrong.

This patch is obviously wrong since I'm using dummy values 1 and 0 as
the selectors for digest and handle members respectively. It's not clear
however what the right solution is since the (M|Unm)arshalling spec
seems to ignore this special case. Hopefully this RFC will get the
discussion started and we can sort out a solution which will probably
require providing feedback to the TCG TSS WG.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>