### PR TITLE
[V2] tcti-socket: Fix build failure due to undeclared HOST_NAME_MAX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,7 @@ AX_ADD_COMPILER_FLAG([-fPIC])
 
 AX_ADD_PREPROC_FLAG([-D_DEFAULT_SOURCE])
 AX_ADD_PREPROC_FLAG([-D_BSD_SOURCE])
+AX_ADD_PREPROC_FLAG([-D_POSIX_SOURCE])
 
 AC_ARG_WITH([loglevel],
             [AS_HELP_STRING([--with-loglevel={none,error,warning,info,debug,trace}],


### PR DESCRIPTION
V2:
- Change to define _POSIX_SOURCE instead of _GNU_SOURCE.

 
The macro HOST_NAME_MAX is defined when _POSIX_SOURCE is defined.
Otherwise, the following build failure may occur.

tcti/tcti_socket.c: In function 'Tss2_Tcti_Socket_Init':
tcti/tcti_socket.c:565:19: error: 'HOST_NAME_MAX' undeclared (first use
in this function)
     char hostname[HOST_NAME_MAX + 1] = { 0 };

[This failure only happens in master branch]

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>