### PR TITLE
Test and Logging: Minor fixes

### DIFF
--- a/log/log.c
+++ b/log/log.c
@@ -27,6 +27,7 @@ doLogBlob(log_level loglevel, const char *module, log_level logdefault,
     size_t width = 8;
     size_t buffer_size = (size * 2) + (size / width) * 2 + 1;
     char buffer[buffer_size];
+    buffer[0] = '\0';
     for (size_t i = 0, off = 0; i < size && off < buffer_size; i++, off+=2) {
         if (width < buffer_size && i % width == 0) {
             *(&buffer[0] + off) = '\n';

--- a/test/unit/tcti-device.c
+++ b/test/unit/tcti-device.c
@@ -115,7 +115,8 @@ tcti_device_setup_with_command (void **state)
 static int
 tcti_device_teardown (void **state)
 {
-    TSS2_TCTI_CONTEXT *ctx = *state;
+    data_t *data = *state;
+    TSS2_TCTI_CONTEXT *ctx = data->ctx;
 
     Tss2_Tcti_Finalize (ctx);
     free (ctx);


### PR DESCRIPTION
These are two minor fixes about a pointer cast mixup and an uninitialized string buffer.