### PR TITLE
log: Replace use of 'index' with 'strchr'.

### DIFF
--- a/log/log.c
+++ b/log/log.c
@@ -98,7 +98,7 @@ getLogLevel(const char *module, log_level logdefault)
     char *i = envlevel;
     if (envlevel == NULL)
         return loglevel;
-    while ((i = index(i, '+')) != NULL) {
+    while ((i = strchr(i, '+')) != NULL) {
         if ((envlevel <= i - strlen("all") && strncasecmp(i - 3, "all", 3) == 0) ||
             (envlevel <= i - strlen(module) &&
              strncasecmp(i - strlen(module), module, strlen(module)) == 0)) {


### PR DESCRIPTION
POSIX.1-2001 classified 'index' as LEGACY and POSIX.1-2008 removes it
completely. It was replaced by strchr and so using that instead is best.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>